### PR TITLE
Improve category state management and navigation

### DIFF
--- a/lib/category/apis/category_api.dart
+++ b/lib/category/apis/category_api.dart
@@ -2,7 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flex_storefront/category/models/category.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-const DOMAIN = 'https://flex-cms-fpnplvnjqq-uc.a.run.app';
+const DOMAIN = 'flex-cms-fpnplvnjqq-uc.a.run.app';
 const PATH = '/api/categories';
 
 class CategoryApi {
@@ -11,13 +11,45 @@ class CategoryApi {
       'Authorization': 'Bearer ${dotenv.get('STRAPI_TOKEN')}',
     };
 
-  Future<List<Category>> fetchCategories({int? parentId}) async {
-    final response = await http.get(
-        '$DOMAIN$PATH?filters[parent][id]${parentId == null ? '[\$null]=true' : '[\$eq]=$parentId'}&populate=*');
+  Future<List<Category>> fetchRootCategories() async {
+    final queryString = {
+      'filters[parent][id][\$null]': 'true',
+      'fields[0]': 'id',
+      'fields[1]': 'name',
+      'populate[image][fields][0]': 'id',
+      'populate[image][fields][1]': 'url',
+      'populate[image][fields][2]': 'name',
+      'populate[children][fields][0]': 'id',
+      'populate[children][fields][1]': 'name',
+    };
+
+    final uri = Uri.https(DOMAIN, PATH, queryString);
+    final response = await http.get(uri.toString());
 
     final result = List<Category>.from(response.data['data'].map(
       (element) => Category.fromJson(element),
     ));
+
+    return result;
+  }
+
+  Future<Category> fetchCategory({required int categoryId}) async {
+    final queryString = {
+      'fields[0]': 'id',
+      'fields[1]': 'name',
+      'populate[image][fields][0]': 'id',
+      'populate[image][fields][1]': 'url',
+      'populate[image][fields][2]': 'name',
+      'populate[children][fields][0]': 'id',
+      'populate[children][fields][1]': 'name',
+      'populate[children][populate][children][fields][0]': 'id',
+      'populate[children][populate][children][fields][1]': 'name',
+    };
+
+    final uri = Uri.https(DOMAIN, '$PATH/$categoryId', queryString);
+    final response = await http.get(uri.toString());
+
+    final result = Category.fromJson(response.data['data']);
 
     return result;
   }

--- a/lib/category/category_page.dart
+++ b/lib/category/category_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flex_storefront/category/cubits/category_cubit.dart';
 import 'package:flex_storefront/category/cubits/category_state.dart';
 import 'package:flex_storefront/router.dart';
+import 'package:flex_storefront/shared/bloc_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -33,26 +34,26 @@ class CategoryView extends StatelessWidget {
     return BlocBuilder<CategoryCubit, CategoryState>(
       builder: (context, state) {
         switch (state.status) {
-          case CategoryStatus.pending:
+          case Status.pending:
             return const Center(
               child: CircularProgressIndicator(),
             );
-          case CategoryStatus.success:
+          case Status.success:
             return ListView(
               children: state.categories
                   .map(
                     (category) => ListTile(
                       title: Text(category.name),
                       onTap: () {
-                        context.router.push(
-                          CategoryIntermediaryRoute(parentCategory: category),
+                        context.router.pushNamed(
+                          'category/${category.id}?title=${category.name}',
                         );
                       },
                     ),
                   )
                   .toList(),
             );
-          case CategoryStatus.failure:
+          case Status.failure:
             return Center(
               child: Column(
                 children: [

--- a/lib/category/cubits/category_cubit.dart
+++ b/lib/category/cubits/category_cubit.dart
@@ -1,24 +1,25 @@
 import 'package:bloc/bloc.dart';
 import 'package:flex_storefront/category/apis/category_api.dart';
 import 'package:flex_storefront/category/cubits/category_state.dart';
+import 'package:flex_storefront/shared/bloc_helper.dart';
 
 class CategoryCubit extends Cubit<CategoryState> {
   final CategoryApi categoryApi = CategoryApi();
 
-  CategoryCubit() : super(CategoryState(status: CategoryStatus.pending));
+  CategoryCubit() : super(CategoryState(status: Status.pending));
 
   Future<void> loadCategories({int? parentId}) async {
     try {
-      emit(CategoryState(status: CategoryStatus.pending));
+      emit(CategoryState(status: Status.pending));
 
-      final categories = await categoryApi.fetchCategories(parentId: parentId);
+      final categories = await categoryApi.fetchRootCategories();
 
       emit(CategoryState(
-        status: CategoryStatus.success,
+        status: Status.success,
         categories: categories,
       ));
     } catch (err) {
-      emit(CategoryState(status: CategoryStatus.failure));
+      emit(CategoryState(status: Status.failure));
     }
   }
 }

--- a/lib/category/cubits/category_intermediary_cubit.dart
+++ b/lib/category/cubits/category_intermediary_cubit.dart
@@ -1,0 +1,28 @@
+import 'package:bloc/bloc.dart';
+import 'package:flex_storefront/category/apis/category_api.dart';
+import 'package:flex_storefront/category/cubits/category_intermediary_state.dart';
+import 'package:flex_storefront/shared/bloc_helper.dart';
+
+class CategoryIntermediaryCubit extends Cubit<CategoryIntermediaryState> {
+  final CategoryApi categoryApi = CategoryApi();
+
+  CategoryIntermediaryCubit()
+      : super(CategoryIntermediaryState(status: Status.pending));
+
+  Future<void> loadCategory({required int categoryId}) async {
+    try {
+      emit(CategoryIntermediaryState(status: Status.pending));
+
+      final category = await categoryApi.fetchCategory(
+        categoryId: categoryId,
+      );
+
+      emit(CategoryIntermediaryState(
+        status: Status.success,
+        category: category,
+      ));
+    } catch (err) {
+      emit(CategoryIntermediaryState(status: Status.failure));
+    }
+  }
+}

--- a/lib/category/cubits/category_intermediary_state.dart
+++ b/lib/category/cubits/category_intermediary_state.dart
@@ -1,17 +1,17 @@
 import 'package:flex_storefront/category/models/category.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
 
-class CategoryState {
+class CategoryIntermediaryState {
   final Status status;
-  final List<Category> categories;
+  final Category? category;
 
-  CategoryState({
+  CategoryIntermediaryState({
     required this.status,
-    this.categories = const [],
+    this.category,
   });
 
   @override
   String toString() {
-    return 'CategoryState{status: $status, categories: ${categories.length}}';
+    return 'CategoryIntermediaryState{status: $status, category: $category}';
   }
 }

--- a/lib/category/models/category.dart
+++ b/lib/category/models/category.dart
@@ -7,11 +7,13 @@ class Category {
   final int id;
   final String name;
   final CategoryImage? image;
+  final List<Category> children;
 
   Category({
     required this.id,
     required this.name,
     this.image,
+    this.children = const [],
   });
 
   factory Category.fromJson(Map<String, dynamic> json) =>
@@ -19,21 +21,25 @@ class Category {
 
   @override
   String toString() {
-    return 'Category{id: $id, name: $name, image: $image}';
+    return 'Category{id: $id, name: $name, image: $image, children: ${children.length}}';
   }
 }
 
 @JsonSerializable(createToJson: false)
 class CategoryImage {
+  final int id;
   final String url;
 
-  CategoryImage({required this.url});
+  /// The file name can help retrieving the different urls for each size.
+  final String name;
+
+  CategoryImage({required this.id, required this.url, required this.name});
 
   factory CategoryImage.fromJson(Map<String, dynamic> json) =>
       _$CategoryImageFromJson(json);
 
   @override
   String toString() {
-    return 'CategoryImage{url: $url}';
+    return 'CategoryImage{id: $id, url: $url, name: $name}';
   }
 }

--- a/lib/category/models/category.g.dart
+++ b/lib/category/models/category.g.dart
@@ -12,9 +12,15 @@ Category _$CategoryFromJson(Map<String, dynamic> json) => Category(
       image: json['image'] == null
           ? null
           : CategoryImage.fromJson(json['image'] as Map<String, dynamic>),
+      children: (json['children'] as List<dynamic>?)
+              ?.map((e) => Category.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
     );
 
 CategoryImage _$CategoryImageFromJson(Map<String, dynamic> json) =>
     CategoryImage(
+      id: json['id'] as int,
       url: json['url'] as String,
+      name: json['name'] as String,
     );

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -3,7 +3,6 @@ import 'package:flex_storefront/account/account_page.dart';
 import 'package:flex_storefront/cart/cart_page.dart';
 import 'package:flex_storefront/category/category_intermediary_page.dart';
 import 'package:flex_storefront/category/category_page.dart';
-import 'package:flex_storefront/category/models/category.dart';
 import 'package:flex_storefront/home/home_page.dart';
 import 'package:flex_storefront/root/root_page.dart';
 import 'package:flex_storefront/shop/shop_page.dart';
@@ -31,7 +30,7 @@ class AppRouter extends _$AppRouter {
                 ),
                 AutoRoute(
                   page: CategoryIntermediaryRoute.page,
-                  path: 'category-interediary',
+                  path: 'category/:categoryId',
                 ),
               ],
             ),

--- a/lib/router.gr.dart
+++ b/lib/router.gr.dart
@@ -28,12 +28,19 @@ abstract class _$AppRouter extends RootStackRouter {
       );
     },
     CategoryIntermediaryRoute.name: (routeData) {
-      final args = routeData.argsAs<CategoryIntermediaryRouteArgs>();
+      final pathParams = routeData.inheritedPathParams;
+      final queryParams = routeData.queryParams;
+      final args = routeData.argsAs<CategoryIntermediaryRouteArgs>(
+          orElse: () => CategoryIntermediaryRouteArgs(
+                categoryId: pathParams.getInt('categoryId'),
+                title: queryParams.optString('title'),
+              ));
       return AutoRoutePage<dynamic>(
         routeData: routeData,
         child: CategoryIntermediaryPage(
-          parentCategory: args.parentCategory,
           key: args.key,
+          categoryId: args.categoryId,
+          title: args.title,
         ),
       );
     },
@@ -97,15 +104,19 @@ class CartRoute extends PageRouteInfo<void> {
 class CategoryIntermediaryRoute
     extends PageRouteInfo<CategoryIntermediaryRouteArgs> {
   CategoryIntermediaryRoute({
-    required Category parentCategory,
     Key? key,
+    required int categoryId,
+    String? title,
     List<PageRouteInfo>? children,
   }) : super(
           CategoryIntermediaryRoute.name,
           args: CategoryIntermediaryRouteArgs(
-            parentCategory: parentCategory,
             key: key,
+            categoryId: categoryId,
+            title: title,
           ),
+          rawPathParams: {'categoryId': categoryId},
+          rawQueryParams: {'title': title},
           initialChildren: children,
         );
 
@@ -117,17 +128,20 @@ class CategoryIntermediaryRoute
 
 class CategoryIntermediaryRouteArgs {
   const CategoryIntermediaryRouteArgs({
-    required this.parentCategory,
     this.key,
+    required this.categoryId,
+    this.title,
   });
-
-  final Category parentCategory;
 
   final Key? key;
 
+  final int categoryId;
+
+  final String? title;
+
   @override
   String toString() {
-    return 'CategoryIntermediaryRouteArgs{parentCategory: $parentCategory, key: $key}';
+    return 'CategoryIntermediaryRouteArgs{key: $key, categoryId: $categoryId, title: $title}';
   }
 }
 

--- a/lib/shared/bloc_helper.dart
+++ b/lib/shared/bloc_helper.dart
@@ -1,0 +1,5 @@
+enum Status {
+  pending,
+  success,
+  failure,
+}


### PR DESCRIPTION
Dedicated cubit for the category intermediary page.

- Lighter request payload
- Ability to navigate between categories with named routes and deeplinks
- We can know whether to display a PLP or a category intermediary depending if the category has children or not