### PR TITLE
feat(ui): add icons_plus and m3 bottomn nav bar

### DIFF
--- a/lib/root/root_page.dart
+++ b/lib/root/root_page.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flex_storefront/router.dart';
 import 'package:flutter/material.dart';
+import 'package:icons_plus/icons_plus.dart';
 
 @RoutePage()
 class RootPage extends StatelessWidget {
@@ -20,27 +21,26 @@ class RootPage extends StatelessWidget {
 
         return Scaffold(
           body: child,
-          bottomNavigationBar: BottomNavigationBar(
-            type: BottomNavigationBarType.fixed,
-            currentIndex: tabsRouter.activeIndex,
-            onTap: (index) {
+          bottomNavigationBar: NavigationBar(
+            selectedIndex: tabsRouter.activeIndex,
+            onDestinationSelected: (index) {
               tabsRouter.setActiveIndex(index);
             },
-            items: const [
-              BottomNavigationBarItem(
-                icon: Icon(Icons.home),
+            destinations: const [
+              NavigationDestination(
+                icon: Icon(LineAwesome.home_solid),
                 label: 'Home',
               ),
-              BottomNavigationBarItem(
-                icon: Icon(Icons.storefront),
+              NavigationDestination(
+                icon: Icon(LineAwesome.tag_solid),
                 label: 'Shop',
               ),
-              BottomNavigationBarItem(
-                icon: Icon(Icons.person),
+              NavigationDestination(
+                icon: Icon(LineAwesome.user_solid),
                 label: 'Account',
               ),
-              BottomNavigationBarItem(
-                icon: Icon(Icons.shopping_cart),
+              NavigationDestination(
+                icon: Icon(LineAwesome.shopping_bag_solid),
                 label: 'Cart',
               ),
             ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,5 @@ dev_dependencies:
   json_serializable: ^6.7.1
 
 flutter:
-  uses-material-design: true
-
   assets:
     - .env

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   flutter_loggy: ^2.0.2
   flutter_loggy_dio: ^3.1.0
   get_it: ^7.6.9
+  icons_plus: ^5.0.0
   json_annotation: ^4.8.1
   loggy: ^2.0.3
   shimmer: ^3.0.0


### PR DESCRIPTION
This PR adds icons_plus package so we can use non-material icons, specifically LineAwesome.

It also moves the BottomNavBar over to NavigationBar (material 3, modern design).

![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-18 at 14 58 53](https://github.com/BASE1com/flex-storefront/assets/3759863/fabd05a9-6ba4-4027-acd3-ff079aa36aed)
