### PR TITLE
[WIP] feat(20-global-cart): add global cart bloc and subscribe via other blocs

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -88,6 +88,9 @@ PODS:
   - PromisesObjC (2.4.0)
   - PromisesSwift (2.4.0):
     - PromisesObjC (= 2.4.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - sqflite (0.0.3):
     - Flutter
     - FlutterMacOS
@@ -98,6 +101,7 @@ DEPENDENCIES:
   - firebase_remote_config (from `.symlinks/plugins/firebase_remote_config/ios`)
   - Flutter (from `Flutter`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite (from `.symlinks/plugins/sqflite/darwin`)
 
 SPEC REPOS:
@@ -130,6 +134,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite:
     :path: ".symlinks/plugins/sqflite/darwin"
 
@@ -155,6 +161,7 @@ SPEC CHECKSUMS:
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
+  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
 
 PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,8 @@
+import 'package:flex_storefront/cart/bloc/global_cart_bloc.dart';
 import 'package:flex_storefront/flex_ui/theme/theme.dart';
 import 'package:flex_storefront/router.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class App extends StatelessWidget {
   App({super.key});
@@ -9,10 +11,13 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      title: 'Flex Storefront',
-      theme: FlexAppTheme.lightTheme,
-      routerConfig: _appRouter.config(),
+    return BlocProvider<GlobalCartBloc>(
+      create: (context) => GlobalCartBloc(),
+      child: MaterialApp.router(
+        title: 'Flex Storefront',
+        theme: FlexAppTheme.lightTheme,
+        routerConfig: _appRouter.config(),
+      ),
     );
   }
 }

--- a/lib/cart/apis/cart_api.dart
+++ b/lib/cart/apis/cart_api.dart
@@ -3,14 +3,18 @@ import 'package:flex_storefront/cart/models/cart.dart';
 import 'package:flex_storefront/init.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get_it/get_it.dart';
+import 'package:loggy/loggy.dart';
 
 const PATH = '/occ/v2/electronics-spa/users/anonymous/carts/';
 const PARAMS =
     '?fields=DEFAULT,potentialProductPromotions,appliedProductPromotions,potentialOrderPromotions,appliedOrderPromotions,entries(totalPrice(formattedValue),product(images(FULL),stock(FULL)),basePrice(formattedValue,value),updateable),totalPrice(formattedValue),totalItems,totalPriceWithTax(formattedValue),totalDiscounts(value,formattedValue),subTotal(formattedValue),totalUnitCount,deliveryItemsQuantity,deliveryCost(formattedValue),totalTax(formattedValue,%20value),pickupItemsQuantity,net,appliedVouchers,productDiscounts(formattedValue),user,saveTime,name,description&lang=en&curr=USD';
 
-class CartApi {
-  final http = Dio();
+mixin CartApiLoggy implements LoggyType {
+  @override
+  Loggy<CartApiLoggy> get loggy => Loggy<CartApiLoggy>('CartApiLoggy');
+}
 
+class CartApi with CartApiLoggy {
   Future<Cart> fetchCart({String? cartCode}) async {
     final response = await GetIt.instance
         .get<Dio>(instanceName: Singletons.hybrisClient)

--- a/lib/cart/bloc/global_cart_bloc.dart
+++ b/lib/cart/bloc/global_cart_bloc.dart
@@ -1,0 +1,65 @@
+import 'package:bloc/bloc.dart';
+import 'package:flex_storefront/cart/apis/cart_api.dart';
+import 'package:flex_storefront/cart/models/cart.dart';
+import 'package:flex_storefront/shared/bloc_helper.dart';
+import 'package:get_it/get_it.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'global_cart_event.dart';
+part 'global_cart_state.dart';
+
+/// The job of this Global Bloc would be to provide all dependent blocs with
+/// a global, near real-time Stream of the Hybris Cart. This cart could be
+/// the anonymous cart or the user cart (or another users cart, depending on
+/// who is logged in). As such, this repository should handle:
+/// 1. Checking if the user is logged in
+/// 2. Checking for the latest cart ids from local device storage
+/// 3. Fetching the cart from the Hybris API
+/// 4. Providing a Stream (or Futures) of the cart to all dependent blocs (at different speeds)
+class GlobalCartBloc extends Bloc<GlobalCartEvent, GlobalCartState> {
+  GlobalCartBloc() : super(GlobalCartState(status: Status.initial)) {
+    on<GlobalCartInitialize>(_onInitCart);
+    on<GlobalCartRequested>(_onCartRequested);
+
+    add(const GlobalCartInitialize());
+  }
+
+  Future<void> _onInitCart(
+    GlobalCartInitialize event,
+    Emitter<GlobalCartState> emit,
+  ) async {
+    final sharedPreferences = await SharedPreferences.getInstance();
+
+    String? anonymousCartGuid =
+        sharedPreferences.getString('anonymous_cart_guid');
+    anonymousCartGuid ??= 'ccf68d7a-1e14-4da1-99d0-21d1f746cb24';
+
+    emit(GlobalCartState(
+      status: Status.success,
+      anonymousCartGuid: anonymousCartGuid,
+    ));
+
+    add(const GlobalCartRequested());
+  }
+
+  Future<void> _onCartRequested(
+    GlobalCartRequested event,
+    Emitter<GlobalCartState> emit,
+  ) async {
+    try {
+      emit(state.copyWith(status: Status.pending));
+
+      // TODO: figure out which cart to fetch (anonymous, user, etc.)
+
+      // fetch the cart
+      final cart = await GetIt.instance
+          .get<CartApi>()
+          .fetchCart(cartCode: state.anonymousCartGuid);
+
+      // emit success
+      emit(state.copyWith(status: Status.success, cart: cart));
+    } catch (e) {
+      emit(state.copyWith(status: Status.failure, error: e));
+    }
+  }
+}

--- a/lib/cart/bloc/global_cart_event.dart
+++ b/lib/cart/bloc/global_cart_event.dart
@@ -1,0 +1,13 @@
+part of 'global_cart_bloc.dart';
+
+sealed class GlobalCartEvent {
+  const GlobalCartEvent();
+}
+
+final class GlobalCartInitialize extends GlobalCartEvent {
+  const GlobalCartInitialize();
+}
+
+final class GlobalCartRequested extends GlobalCartEvent {
+  const GlobalCartRequested();
+}

--- a/lib/cart/bloc/global_cart_state.dart
+++ b/lib/cart/bloc/global_cart_state.dart
@@ -1,0 +1,37 @@
+part of 'global_cart_bloc.dart';
+
+final class GlobalCartState extends BlocState {
+  final String anonymousCartGuid;
+  final Cart? cart;
+
+  GlobalCartState({
+    required super.status,
+    super.error,
+    super.stackTrace,
+    this.anonymousCartGuid = '',
+    this.cart,
+  });
+
+  int get totalItems => cart?.totalItems ?? 0;
+
+  GlobalCartState copyWith({
+    Status? status,
+    String? anonymousCartGuid,
+    Cart? cart,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    return GlobalCartState(
+      status: status ?? this.status,
+      anonymousCartGuid: anonymousCartGuid ?? this.anonymousCartGuid,
+      cart: cart ?? this.cart,
+      error: error ?? this.error,
+      stackTrace: stackTrace ?? this.stackTrace,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'GlobalCartState{status: $status, anonymousCartGuid: $anonymousCartGuid, cart: $cart}';
+  }
+}

--- a/lib/cart/cart_page.dart
+++ b/lib/cart/cart_page.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/annotations.dart';
+import 'package:flex_storefront/cart/bloc/global_cart_bloc.dart';
 import 'package:flex_storefront/cart/cubits/cart_cubit.dart';
 import 'package:flex_storefront/cart/cubits/cart_state.dart';
 import 'package:flex_storefront/cart/widgets/cart_content.dart';
@@ -14,7 +15,9 @@ class CartPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider<CartCubit>(
-      create: (context) => CartCubit()..loadCart(),
+      create: (context) => CartCubit(
+        globalCartBloc: context.read<GlobalCartBloc>(),
+      )..loadCart(),
       child: const CartView(),
     );
   }
@@ -35,7 +38,7 @@ class CartView extends StatelessWidget {
       body: BlocBuilder<CartCubit, CartState>(
         builder: (context, state) {
           switch (state.status) {
-            case Status.pending:
+            case Status.initial || Status.pending:
               return const Center(
                 child: CircularProgressIndicator(),
               );

--- a/lib/category/category_intermediary_page.dart
+++ b/lib/category/category_intermediary_page.dart
@@ -45,7 +45,7 @@ class CategoryIntermediaryView extends StatelessWidget {
     return BlocBuilder<CategoryIntermediaryCubit, CategoryIntermediaryState>(
       builder: (context, state) {
         switch (state.status) {
-          case Status.pending:
+          case Status.initial || Status.pending:
             return const Center(
               child: CircularProgressIndicator(),
             );

--- a/lib/category/category_page.dart
+++ b/lib/category/category_page.dart
@@ -37,7 +37,7 @@ class CategoryView extends StatelessWidget {
     return BlocBuilder<CategoryCubit, CategoryState>(
       builder: (context, state) {
         switch (state.status) {
-          case Status.pending:
+          case Status.initial || Status.pending:
             return const Center(
               child: CircularProgressIndicator(),
             );

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -5,7 +5,6 @@ import 'package:flex_storefront/flex_ui/tokens/colors.dart';
 import 'package:flex_storefront/flex_ui/widgets/cached_image.dart';
 import 'package:flex_storefront/home/home_page_content.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
-import 'package:flutter/cupertino.dart';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -32,15 +31,6 @@ class HomeView extends StatelessWidget {
       slivers: [
         SliverAppBar(
           backgroundColor: FlexColors.primary,
-          actions: [
-            IconButton(
-              onPressed: () {},
-              icon: const Icon(
-                Icons.shopping_cart,
-                color: Colors.white,
-              ),
-            )
-          ],
           pinned: true,
           expandedHeight: 200,
           flexibleSpace: FlexibleSpaceBar(
@@ -64,7 +54,7 @@ class HomeView extends StatelessWidget {
           child: BlocBuilder<CmsCubit, CmsState>(
             builder: (_, state) {
               switch (state.status) {
-                case Status.pending:
+                case Status.initial || Status.pending:
                   return const Center(
                     child: CircularProgressIndicator(),
                   );

--- a/lib/init.dart
+++ b/lib/init.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flex_storefront/cart/apis/cart_api.dart';
 import 'package:flex_storefront/category/apis/category_api.dart';
 import 'package:flex_storefront/cms/apis/cms_api.dart';
 import 'package:flex_storefront/config/config_repository.dart';
@@ -27,6 +28,7 @@ void init() {
     instanceName: Singletons.hybrisClient,
   );
 
+  GetIt.instance.registerSingleton(CartApi());
   GetIt.instance.registerSingleton(CategoryApi());
   GetIt.instance.registerSingleton(CmsApi());
   GetIt.instance.registerSingleton(ProductApi());

--- a/lib/product_detail/product_detail_page.dart
+++ b/lib/product_detail/product_detail_page.dart
@@ -42,7 +42,7 @@ class ProductDetailView extends StatelessWidget {
       body: BlocBuilder<ProductDetailCubit, ProductDetailState>(
         builder: (context, state) {
           switch (state.status) {
-            case Status.pending:
+            case Status.initial || Status.pending:
               return const Center(
                 child: CircularProgressIndicator(),
               );

--- a/lib/root/cubit/cart_icon_cubit.dart
+++ b/lib/root/cubit/cart_icon_cubit.dart
@@ -2,14 +2,14 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:flex_storefront/cart/bloc/global_cart_bloc.dart';
-import 'package:flex_storefront/cart/cubits/cart_state.dart';
+import 'package:flex_storefront/root/cubit/cart_icon_state.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
 
-class CartCubit extends Cubit<CartState> {
-  CartCubit({
+class CartIconCubit extends Cubit<CartIconState> {
+  CartIconCubit({
     required GlobalCartBloc globalCartBloc,
   })  : _globalCartBloc = globalCartBloc,
-        super(CartState(status: Status.pending)) {
+        super(CartIconState(status: Status.success)) {
     subscribe();
   }
 
@@ -20,22 +20,13 @@ class CartCubit extends Cubit<CartState> {
     _streamSubscription = _globalCartBloc.stream.listen(
       (state) {
         if (state.status == Status.success) {
-          emit(CartState(
+          emit(CartIconState(
             status: Status.success,
-            cart: state.cart,
+            totalItems: state.totalItems,
           ));
         }
       },
     );
-  }
-
-  Future<void> loadCart() async {
-    try {
-      emit(CartState(status: Status.pending));
-      _globalCartBloc.add(const GlobalCartRequested());
-    } catch (err) {
-      emit(CartState(status: Status.failure));
-    }
   }
 
   @override

--- a/lib/root/cubit/cart_icon_state.dart
+++ b/lib/root/cubit/cart_icon_state.dart
@@ -1,0 +1,17 @@
+import 'package:flex_storefront/shared/bloc_helper.dart';
+
+class CartIconState extends BlocState {
+  final int totalItems;
+
+  CartIconState({
+    required super.status,
+    super.error,
+    super.stackTrace,
+    this.totalItems = 0,
+  });
+
+  @override
+  String toString() {
+    return 'CartIconState{status: $status, totalItems: $totalItems}';
+  }
+}

--- a/lib/root/root_page.dart
+++ b/lib/root/root_page.dart
@@ -1,6 +1,10 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:flex_storefront/cart/bloc/global_cart_bloc.dart';
+import 'package:flex_storefront/root/cubit/cart_icon_cubit.dart';
+import 'package:flex_storefront/root/widgets/cart_icon.dart';
 import 'package:flex_storefront/router.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:icons_plus/icons_plus.dart';
 
 @RoutePage()
@@ -19,31 +23,36 @@ class RootPage extends StatelessWidget {
       builder: (context, child) {
         final tabsRouter = AutoTabsRouter.of(context);
 
-        return Scaffold(
-          body: child,
-          bottomNavigationBar: NavigationBar(
-            selectedIndex: tabsRouter.activeIndex,
-            onDestinationSelected: (index) {
-              tabsRouter.setActiveIndex(index);
-            },
-            destinations: const [
-              NavigationDestination(
-                icon: Icon(LineAwesome.home_solid),
-                label: 'Home',
-              ),
-              NavigationDestination(
-                icon: Icon(LineAwesome.tag_solid),
-                label: 'Shop',
-              ),
-              NavigationDestination(
-                icon: Icon(LineAwesome.user_solid),
-                label: 'Account',
-              ),
-              NavigationDestination(
-                icon: Icon(LineAwesome.shopping_bag_solid),
-                label: 'Cart',
-              ),
-            ],
+        return BlocProvider<CartIconCubit>(
+          create: (context) => CartIconCubit(
+            globalCartBloc: context.read<GlobalCartBloc>(),
+          ),
+          child: Scaffold(
+            body: child,
+            bottomNavigationBar: NavigationBar(
+              selectedIndex: tabsRouter.activeIndex,
+              onDestinationSelected: (index) {
+                tabsRouter.setActiveIndex(index);
+              },
+              destinations: const [
+                NavigationDestination(
+                  icon: Icon(LineAwesome.home_solid),
+                  label: 'Home',
+                ),
+                NavigationDestination(
+                  icon: Icon(LineAwesome.tag_solid),
+                  label: 'Shop',
+                ),
+                NavigationDestination(
+                  icon: Icon(LineAwesome.user_solid),
+                  label: 'Account',
+                ),
+                NavigationDestination(
+                  icon: CartIcon(),
+                  label: 'Cart',
+                ),
+              ],
+            ),
           ),
         );
       },

--- a/lib/root/widgets/cart_icon.dart
+++ b/lib/root/widgets/cart_icon.dart
@@ -1,0 +1,35 @@
+import 'package:badges/badges.dart' as badges;
+import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
+import 'package:flex_storefront/root/cubit/cart_icon_cubit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:icons_plus/icons_plus.dart';
+
+class CartIcon extends StatelessWidget {
+  const CartIcon({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final count =
+        context.select((CartIconCubit cubit) => cubit.state.totalItems);
+
+    return badges.Badge(
+      position: badges.BadgePosition.topEnd(top: -12, end: -16),
+      badgeContent: Text(
+        count.toString(),
+        style: const TextStyle(
+          fontSize: FlexSizes.fontSizeXs,
+          color: Colors.white,
+        ),
+      ),
+      badgeAnimation: const badges.BadgeAnimation.slide(
+        animationDuration: Duration(seconds: 1),
+        colorChangeAnimationDuration: Duration(seconds: 1),
+        loopAnimation: false,
+        curve: Curves.fastOutSlowIn,
+        colorChangeAnimationCurve: Curves.easeInCubic,
+      ),
+      child: const Icon(LineAwesome.shopping_bag_solid),
+    );
+  }
+}

--- a/lib/shared/bloc_helper.dart
+++ b/lib/shared/bloc_helper.dart
@@ -2,6 +2,7 @@ import 'package:bloc/bloc.dart';
 import 'package:loggy/loggy.dart';
 
 enum Status {
+  initial,
   pending,
   success,
   failure,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.3.2"
+  badges:
+    dependency: "direct main"
+    description:
+      name: badges
+      sha256: a7b6bbd60dce418df0db3058b53f9d083c22cdb5132a052145dc267494df0b84
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   bloc:
     dependency: "direct main"
     description:
@@ -792,6 +800,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "1ee8bf911094a1b592de7ab29add6f826a7331fb854273d55918693d5364a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "7708d83064f38060c7b39db12aefe449cb8cdc031d6062280087bc4cdb988f5c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.5"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: "9aee1089b36bd2aafe06582b7d7817fd317ef05fc30e6ba14bff247d0933042a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   sheet:
     dependency: "direct main"
     description:
@@ -1079,4 +1143,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.16.0"
+  flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   auto_route: ^7.9.2
+  badges: ^3.1.2
   bloc: ^8.1.3
   cached_network_image: ^3.3.1
   collection: ^1.18.0
@@ -29,6 +30,7 @@ dependencies:
   icons_plus: ^5.0.0
   json_annotation: ^4.8.1
   loggy: ^2.0.3
+  shared_preferences: ^2.2.3
   sheet: ^1.0.0
   shimmer: ^3.0.0
   widgetbook: ^3.7.1


### PR DESCRIPTION
This PR is a work-in-progress [WIP] and proof-of-concept for a "global cart bloc".

The job of this Global Bloc would be to provide all dependent blocs with a global, near real-time Stream of the Hybris Cart. This cart could be the anonymous cart or the user cart (or another users cart, depending on who is logged in). As such, this Global Bloc should handle:
1. Checking if the user is logged in
2. Checking for the latest cart ids from local device storage
3. Fetching the cart from the Hybris API
4. Providing a Stream (or Futures) of the cart to all dependent blocs (at different speeds)

It would be injected either via arguments or GetIt singleton into all dependent, smaller blocs so they only have to worry about their specific use cases regarding the Cart, and not the overall complexities. This should simplify and keep the code clean with defined responsibilities per sub-bloc.

In the future, this Global Bloc may implement a "fetch policies" approach so it can be performant and utilize the cache to increase speed whenever possible (a.k.a. not during checkout, validation, etc.).

This PR is open to comment and feedback as we are still trying figure out the best architecture for an optimal cart experience which is central to the ecommerce app.