### PR TITLE
[POC] fix(5-cart): refactor cart subscription to abstract class

### DIFF
--- a/lib/cart/cubits/cart_icon_cubit.dart
+++ b/lib/cart/cubits/cart_icon_cubit.dart
@@ -1,40 +1,21 @@
-import 'dart:async';
-
-import 'package:bloc/bloc.dart';
-import 'package:flex_storefront/cart/apis/cart_api.dart';
-import 'package:flex_storefront/cart/cart_repository.dart';
 import 'package:flex_storefront/cart/cubits/cart_icon_state.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
-import 'package:get_it/get_it.dart';
+import 'package:flex_storefront/shared/utils/cart_subscription_cubit.dart';
 
-class CartIconCubit extends Cubit<CartIconState> {
-  final CartApi cartApi = CartApi();
+class CartIconCubit extends CartSubscriptionCubit<CartIconState> {
+  CartIconCubit() : super(CartIconState(status: Status.initial));
 
-  CartIconCubit() : super(CartIconState(status: Status.initial)) {
-    _subscribe();
-  }
-
-  late final StreamSubscription _cartStreamSubscription;
-
-  Future<void> _subscribe() async {
-    _cartStreamSubscription =
-        GetIt.instance.get<CartRepository>().getCartStream().listen(
-      (cart) {
-        emit(CartIconState(
-          status: Status.success,
-          totalItems: cart.totalItems,
-        ));
-      },
-      onError: (err, stackTrace) {
-        emit(CartIconState(status: Status.failure));
-        addError(err, stackTrace);
-      },
-    );
+  @override
+  void onCartData(cart) {
+    emit(CartIconState(
+      status: Status.success,
+      totalItems: cart.totalItems,
+    ));
   }
 
   @override
-  Future<void> close() {
-    _cartStreamSubscription.cancel();
-    return super.close();
+  void onCartError(err, stackTrace) {
+    emit(CartIconState(status: Status.failure));
+    addError(err, stackTrace);
   }
 }

--- a/lib/shared/utils/cart_subscription_cubit.dart
+++ b/lib/shared/utils/cart_subscription_cubit.dart
@@ -40,9 +40,9 @@ abstract class CartSubscriptionCubit<T> extends Cubit<T> {
   void onCartError(err, stackTrace);
 
   @override
-  Future<void> close() {
-    _cartStreamSubscription.cancel();
-    _cartMessageStreamSubscription.cancel();
+  Future<void> close() async {
+    await _cartStreamSubscription.cancel();
+    await _cartMessageStreamSubscription.cancel();
     return super.close();
   }
 }

--- a/lib/shared/utils/cart_subscription_cubit.dart
+++ b/lib/shared/utils/cart_subscription_cubit.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+import 'package:bloc/bloc.dart';
+import 'package:flex_storefront/cart/cart_repository.dart';
+import 'package:flex_storefront/cart/models/cart.dart';
+import 'package:flex_storefront/cart/models/cart_message.dart';
+import 'package:get_it/get_it.dart';
+
+abstract class CartSubscriptionCubit<T> extends Cubit<T> {
+  late final StreamSubscription _cartStreamSubscription;
+  late final StreamSubscription _cartMessageStreamSubscription;
+
+  CartSubscriptionCubit(T initialState) : super(initialState) {
+    _subscribe();
+  }
+
+  void _subscribe() {
+    _cartStreamSubscription =
+        GetIt.instance.get<CartRepository>().getCartStream().listen(
+      (cart) {
+        onCartData(cart);
+      },
+      onError: (err, stackTrace) {
+        onCartError(err, stackTrace);
+      },
+    );
+
+    _cartMessageStreamSubscription =
+        GetIt.instance.get<CartRepository>().getCartMessageStream().listen(
+      (message) {
+        onCartMessage(message);
+      },
+      onError: (err, stackTrace) {
+        onCartError(err, stackTrace);
+      },
+    );
+  }
+
+  void onCartData(Cart cart);
+  void onCartMessage(CartMessage message) {}
+  void onCartError(err, stackTrace);
+
+  @override
+  Future<void> close() {
+    _cartStreamSubscription.cancel();
+    _cartMessageStreamSubscription.cancel();
+    return super.close();
+  }
+}


### PR DESCRIPTION
This PR refactors the CartIconCubit into a composed class on top of a new `CartSubscriptionCubit` class.

I'm not 100% sure this is the right move, but it feels more DRY and better than repeating this same boilerplate in every single micro-cubit, and ensures we don't miss closing a stream subscription.