### PR TITLE
feat(39-analytics): Google Analytics implementation

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,9 @@
 PODS:
+  - Firebase/Analytics (10.24.0):
+    - Firebase/Core
+  - Firebase/Core (10.24.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (~> 10.24.0)
   - Firebase/CoreOnly (10.24.0):
     - FirebaseCore (= 10.24.0)
   - Firebase/Crashlytics (10.24.0):
@@ -7,6 +12,10 @@ PODS:
   - Firebase/RemoteConfig (10.24.0):
     - Firebase/CoreOnly
     - FirebaseRemoteConfig (~> 10.24.0)
+  - firebase_analytics (10.10.4):
+    - Firebase/Analytics (= 10.24.0)
+    - firebase_core
+    - Flutter
   - firebase_core (2.30.1):
     - Firebase/CoreOnly (= 10.24.0)
     - Flutter
@@ -20,6 +29,24 @@ PODS:
     - Flutter
   - FirebaseABTesting (10.24.0):
     - FirebaseCore (~> 10.0)
+  - FirebaseAnalytics (10.24.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.24.0)
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebaseAnalytics/AdIdSupport (10.24.0):
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleAppMeasurement (= 10.24.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30911.0, >= 2.30908.0)
   - FirebaseCore (10.24.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
@@ -61,19 +88,55 @@ PODS:
     - PromisesSwift (~> 2.1)
   - FirebaseSharedSwift (10.24.0)
   - Flutter (1.0.0)
+  - GoogleAppMeasurement (10.24.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.24.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - GoogleAppMeasurement/AdIdSupport (10.24.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.24.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.24.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30911.0, >= 2.30908.0)
   - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/AppDelegateSwizzler (7.13.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+    - GoogleUtilities/Privacy
   - GoogleUtilities/Environment (7.13.0):
     - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.13.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
+  - GoogleUtilities/MethodSwizzler (7.13.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (7.13.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
+    - GoogleUtilities/Reachability
   - "GoogleUtilities/NSData+zlib (7.13.0)":
     - GoogleUtilities/Privacy
   - GoogleUtilities/Privacy (7.13.0)
+  - GoogleUtilities/Reachability (7.13.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
   - GoogleUtilities/UserDefaults (7.13.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
@@ -93,6 +156,7 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - firebase_remote_config (from `.symlinks/plugins/firebase_remote_config/ios`)
@@ -104,6 +168,7 @@ SPEC REPOS:
   trunk:
     - Firebase
     - FirebaseABTesting
+    - FirebaseAnalytics
     - FirebaseCore
     - FirebaseCoreExtension
     - FirebaseCoreInternal
@@ -113,6 +178,7 @@ SPEC REPOS:
     - FirebaseRemoteConfigInterop
     - FirebaseSessions
     - FirebaseSharedSwift
+    - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
     - nanopb
@@ -120,6 +186,8 @@ SPEC REPOS:
     - PromisesSwift
 
 EXTERNAL SOURCES:
+  firebase_analytics:
+    :path: ".symlinks/plugins/firebase_analytics/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   firebase_crashlytics:
@@ -135,10 +203,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Firebase: 91fefd38712feb9186ea8996af6cbdef41473442
+  firebase_analytics: 573fd0677abf22d32e2820865fc5190b6cdbfa1b
   firebase_core: 7f1e1156934d0da3be260174812842df9420e4ab
   firebase_crashlytics: 9815effbfaad6c94c65d4eff479c0d9284bf1a38
   firebase_remote_config: bb9853d3dbca8dc788152371fdfefe982e25a2c8
   FirebaseABTesting: 4431c2c56ac6e56f463b9cab05cc111078639f99
+  FirebaseAnalytics: b5efc493eb0f40ec560b04a472e3e1a15d39ca13
   FirebaseCore: 11dc8a16dfb7c5e3c3f45ba0e191a33ac4f50894
   FirebaseCoreExtension: af5fd85e817ea9d19f9a2659a376cf9cf99f03c0
   FirebaseCoreInternal: bcb5acffd4ea05e12a783ecf835f2210ce3dc6af
@@ -149,6 +219,7 @@ SPEC CHECKSUMS:
   FirebaseSessions: 2651b464e241c93fd44112f995d5ab663c970487
   FirebaseSharedSwift: 76e1529c32101d80e4f1ca2fba7c39d59f0a390a
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  GoogleAppMeasurement: f3abf08495ef2cba7829f15318c373b8d9226491
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
   nanopb: 438bc412db1928dac798aa6fd75726007be04262

--- a/lib/analytics/apis/analytics_api.dart
+++ b/lib/analytics/apis/analytics_api.dart
@@ -1,0 +1,58 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flex_storefront/analytics/models/analytics_events.dart';
+import 'package:get_it/get_it.dart';
+import 'package:loggy/loggy.dart';
+
+mixin AnalyticsApiLoggy implements LoggyType {
+  @override
+  Loggy<AnalyticsApiLoggy> get loggy =>
+      Loggy<AnalyticsApiLoggy>('AnalyticsApiLoggy');
+}
+
+class AnalyticsApi with AnalyticsApiLoggy {
+  Future<void> track(AnalyticsEvent event) async {
+    loggy.info('Track Analytics event $event');
+    if (event is ViewItemEvent) {
+      await GetIt.instance.get<FirebaseAnalytics>().logViewItem(
+            currency: event.currency,
+            value: event.value,
+            items: event.items,
+            parameters: event.parameters,
+          );
+    } else if (event is SelectContentEvent) {
+      await GetIt.instance.get<FirebaseAnalytics>().logSelectContent(
+            itemId: event.itemId,
+            contentType: event.contentType,
+            parameters: event.parameters,
+          );
+    } else if (event is ViewCartEvent) {
+      await GetIt.instance.get<FirebaseAnalytics>().logViewCart(
+            currency: event.currency,
+            value: event.value,
+            items: event.items,
+            parameters: event.parameters,
+          );
+    } else if (event is AddToCartEvent) {
+      await GetIt.instance.get<FirebaseAnalytics>().logAddToCart(
+            currency: event.currency,
+            value: event.value,
+            items: event.items,
+            parameters: event.parameters,
+          );
+    } else if (event is RemoveFromCartEvent) {
+      await GetIt.instance.get<FirebaseAnalytics>().logRemoveFromCart(
+            currency: event.currency,
+            value: event.value,
+            items: event.items,
+            parameters: event.parameters,
+          );
+    } else {
+      loggy.warning('Unhandled event type: ${event.runtimeType}');
+    }
+  }
+
+  Future<void> setUserId(String? userId) async {
+    loggy.info('Set the userId to: $userId');
+    await GetIt.instance.get<FirebaseAnalytics>().setUserId(id: userId);
+  }
+}

--- a/lib/analytics/models/analytics_events.dart
+++ b/lib/analytics/models/analytics_events.dart
@@ -1,0 +1,147 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flex_storefront/cart/models/cart.dart';
+import 'package:flex_storefront/product_list/models/product.dart';
+
+abstract class AnalyticsEvent {
+  final Map<String, Object?>? parameters;
+
+  const AnalyticsEvent({this.parameters});
+}
+
+abstract class AnalyticsItemsEvent extends AnalyticsEvent {
+  final String? currency;
+  final double? value;
+  final List<AnalyticsEventItem>? items;
+
+  const AnalyticsItemsEvent({
+    this.currency,
+    this.value,
+    this.items,
+    super.parameters,
+  });
+
+  @override
+  String toString() {
+    return '$runtimeType{currency: $currency, value: $value, items: $items}';
+  }
+}
+
+/// This event signifies that some content was shown to the user.
+/// Use this event to discover the most popular items viewed.
+class ViewItemEvent extends AnalyticsItemsEvent {
+  const ViewItemEvent({
+    super.currency,
+    super.value,
+    super.items,
+    super.parameters,
+  });
+
+  factory ViewItemEvent.fromProduct(Product product) {
+    return ViewItemEvent(
+      currency: product.price?.currencyIso,
+      value: product.price?.value,
+      items: [
+        AnalyticsEventItem(
+          itemId: product.code,
+          itemName: product.name,
+          price: product.price?.value,
+        )
+      ],
+    );
+  }
+}
+
+/// This event signifies that a user has selected some content of a certain type.
+/// This event can help you identify popular content and categories of content on your website or app.
+class SelectContentEvent extends AnalyticsEvent {
+  final String contentType;
+  final String itemId;
+
+  const SelectContentEvent({
+    required this.contentType,
+    required this.itemId,
+    super.parameters,
+  });
+
+  factory SelectContentEvent.fromCategoryCode(String categoryCode) {
+    return SelectContentEvent(
+      contentType: 'category',
+      itemId: categoryCode,
+    );
+  }
+}
+
+/// This event signifies that a user viewed their cart.
+class ViewCartEvent extends AnalyticsItemsEvent {
+  const ViewCartEvent({
+    super.currency,
+    super.value,
+    super.items,
+    super.parameters,
+  });
+
+  factory ViewCartEvent.fromCart(Cart cart) {
+    return ViewCartEvent(
+      currency: cart.totalPrice.currencyIso,
+      value: cart.totalPrice.value,
+      items: cart.entries
+          .map((entry) => AnalyticsEventItem(
+                itemId: entry.product.code,
+                itemName: entry.product.name,
+                price: entry.basePrice.value,
+                quantity: entry.quantity,
+              ))
+          .toList(),
+    );
+  }
+}
+
+/// This event signifies that an item was added to a cart.
+class AddToCartEvent extends AnalyticsItemsEvent {
+  const AddToCartEvent({
+    super.currency,
+    super.value,
+    super.items,
+    super.parameters,
+  });
+
+  factory AddToCartEvent.fromData(Product product, int quantity) {
+    return AddToCartEvent(
+      currency: product.price?.currencyIso,
+      value: product.price?.value,
+      items: [
+        AnalyticsEventItem(
+          itemId: product.code,
+          itemName: product.name,
+          price: product.price?.value,
+          quantity: quantity,
+        )
+      ],
+    );
+  }
+}
+
+/// This event signifies that an item was removed from a cart.
+class RemoveFromCartEvent extends AnalyticsItemsEvent {
+  const RemoveFromCartEvent({
+    super.currency,
+    super.value,
+    super.items,
+    super.parameters,
+  });
+
+  factory RemoveFromCartEvent.fromData(Product product, int quantity) {
+    return RemoveFromCartEvent(
+      currency: product.price?.currencyIso,
+      value: product.price?.value,
+      items: [
+        AnalyticsEventItem(
+          itemId: product.code,
+          itemName: product.name,
+          price: product.price?.value,
+          quantity: quantity,
+        )
+      ],
+    );
+  }
+}

--- a/lib/home/home_page_content.dart
+++ b/lib/home/home_page_content.dart
@@ -58,7 +58,7 @@ class HomePageContent extends StatelessWidget {
       } else if (section is ProductCarouselData) {
         return BlocProvider<ProductListCubit>(
           create: (_) => ProductListCubit()
-            ..loadProductsfromIds(productIds: section.productCodes),
+            ..loadProductsFromIds(productIds: section.productCodes),
           child: BlocBuilder<ProductListCubit, ProductListState>(
               builder: (context, state) {
             return FlexCarousel(

--- a/lib/init.dart
+++ b/lib/init.dart
@@ -1,4 +1,6 @@
 import 'package:dio/dio.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flex_storefront/analytics/apis/analytics_api.dart';
 import 'package:flex_storefront/cart/apis/cart_api.dart';
 import 'package:flex_storefront/cart/cart_repository.dart';
 import 'package:flex_storefront/category/apis/category_api.dart';
@@ -16,6 +18,7 @@ class Singletons {
 }
 
 void init() {
+  // Third-party singletons
   GetIt.instance.registerSingleton(
     Dio()
       ..interceptors.add(LoggyDioInterceptor(responseBody: false))
@@ -29,11 +32,17 @@ void init() {
     instanceName: Singletons.hybrisClient,
   );
 
-  GetIt.instance.registerSingleton(CartRepository(cartApi: CartApi()));
+  GetIt.instance.registerSingleton(FirebaseAnalytics.instance);
+
+  // Api layer
+  GetIt.instance.registerSingleton(AnalyticsApi());
   GetIt.instance.registerSingleton(CategoryApi());
   GetIt.instance.registerSingleton(CmsApi());
   GetIt.instance.registerSingleton(ProductApi());
   GetIt.instance.registerSingleton(ProductListApi());
+
+  // Repository layer
+  GetIt.instance.registerSingleton(CartRepository(cartApi: CartApi()));
 
   GetIt.instance.registerSingletonAsync(() async {
     final ConfigRepository configRepository = ConfigRepository();

--- a/lib/product_detail/cubits/product_detail_state.dart
+++ b/lib/product_detail/cubits/product_detail_state.dart
@@ -1,13 +1,14 @@
 import 'package:flex_storefront/product_list/models/product.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
 
-class ProductDetailState {
-  final Status status;
+class ProductDetailState extends BlocState {
   final Product? product;
   final int quantity;
 
   ProductDetailState({
-    required this.status,
+    required super.status,
+    super.error,
+    super.stackTrace,
     this.product,
     this.quantity = 1,
   });

--- a/lib/product_list/apis/product_list_api.dart
+++ b/lib/product_list/apis/product_list_api.dart
@@ -11,24 +11,6 @@ const PARAMS =
     '?fields=products(code%2Cname%2Csummary%2Cconfigurable%2CconfiguratorType%2Cmultidimensional%2Cprice(FULL)%2Cimages(DEFAULT)%2Cstock(FULL)%2CaverageRating%2CvariantOptions)%2Cfacets%2Cbreadcrumbs%2Cpagination(DEFAULT)%2Csorts(DEFAULT)%2CfreeTextSearch%2CcurrentQuery&pageSize=12&lang=en&curr=USD';
 
 class ProductListApi {
-  Future<SearchResults> fetchProducts({
-    String? categoryCode,
-  }) async {
-    final path = PATH.replaceAll(
-      '<CATALOG>',
-      GetIt.instance
-          .get<ConfigRepository>()
-          .getString(ConfigKey.shopHybrisCatalog),
-    );
-
-    final response = await GetIt.instance
-        .get<Dio>(instanceName: Singletons.hybrisClient)
-        .get(
-            '${dotenv.get('HYBRIS_BASE_URL')}$path$PARAMS&query=%3Arelevance%3AallCategories%3A$categoryCode');
-
-    return SearchResults.fromJson(response.data);
-  }
-
   Future<SearchResults> searchProducts({
     required String query,
     int page = 0,

--- a/lib/product_list/cubits/product_list_cubit.dart
+++ b/lib/product_list/cubits/product_list_cubit.dart
@@ -9,28 +9,7 @@ import 'package:get_it/get_it.dart';
 class ProductListCubit extends Cubit<ProductListState> {
   ProductListCubit() : super(ProductListState(status: Status.pending));
 
-  Future<void> loadProducts({String? categoryCode}) async {
-    try {
-      emit(ProductListState(status: Status.pending));
-
-      final searchResults = await GetIt.instance
-          .get<ProductListApi>()
-          .fetchProducts(categoryCode: categoryCode);
-
-      emit(ProductListState(
-        status: Status.success,
-        products: searchResults.products,
-      ));
-    } on DioException catch (error) {
-      emit(ProductListState(
-        status: Status.failure,
-        error: error,
-        stackTrace: error.stackTrace,
-      ));
-    }
-  }
-
-  Future<void> loadProductsfromIds({required List<String> productIds}) async {
+  Future<void> loadProductsFromIds({required List<String> productIds}) async {
     for (var id in productIds) {
       GetIt.instance
           .get<ProductApi>()

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -281,6 +281,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  firebase_analytics:
+    dependency: "direct main"
+    description:
+      name: firebase_analytics
+      sha256: c56bcc7abc6caacc33e8495bc604a5861d25ce371f1b06476ae226e7cbb21d4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.10.4"
+  firebase_analytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_analytics_platform_interface
+      sha256: e8cdb845820eaa5f1d29de31a72aab8addbbffc6483f1e5123a9d0b611735285
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.10.5"
+  firebase_analytics_web:
+    dependency: transitive
+    description:
+      name: firebase_analytics_web
+      sha256: e2fabebdf16bb99506a1e7e84f5effd6313c90678e6ea1876d301f057483a198
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.7+4"
   firebase_core:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   cached_network_image: ^3.3.1
   collection: ^1.18.0
   dio: ^5.4.1
+  firebase_analytics: ^10.10.4
   firebase_core: ^2.30.1
   firebase_crashlytics: ^3.5.4
   firebase_remote_config: ^4.4.4


### PR DESCRIPTION
Google Analytics implementation, the events are:

- `ViewItemEvent` 👉 Opening the PDP
- `SelectContentEvent` 👉 Opening the PLP fron a category (the event is populated with the category)
- `ViewCartEvent` 👉 Opening the cart page
- `AddToCartEvent` 👉 Add an item to the cart 
- `RemoveFromCartEvent` 👉 Removing an item from the cart

For now, only the `ViewItemEvent` is tracked (in `ProductDetailCubit`, `loadProduct` method), for the others, I'm still looking for a place to call the track method:
1. where the data (cart or product or category, etc) is available
2. called only once.