### PR TITLE
fix(cart): handle cart not found exceptions

### DIFF
--- a/lib/cart/apis/cart_api.dart
+++ b/lib/cart/apis/cart_api.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flex_storefront/cart/apis/cart_exceptions.dart';
 import 'package:flex_storefront/cart/models/cart.dart';
 import 'package:flex_storefront/init.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -8,15 +9,39 @@ const PATH = '/occ/v2/electronics-spa/users/anonymous/carts/';
 const PARAMS =
     '?fields=DEFAULT,potentialProductPromotions,appliedProductPromotions,potentialOrderPromotions,appliedOrderPromotions,entries(totalPrice(formattedValue),product(images(FULL),stock(FULL)),basePrice(formattedValue,value),updateable),totalPrice(formattedValue),totalItems,totalPriceWithTax(formattedValue),totalDiscounts(value,formattedValue),subTotal(formattedValue),totalUnitCount,deliveryItemsQuantity,deliveryCost(formattedValue),totalTax(formattedValue,%20value),pickupItemsQuantity,net,appliedVouchers,productDiscounts(formattedValue),user,saveTime,name,description&lang=en&curr=USD';
 
+const NEW_CART_PARAMS =
+    'DEFAULT,potentialProductPromotions,appliedProductPromotions,potentialOrderPromotions,appliedOrderPromotions,entries(totalPrice(formattedValue),product(images(FULL),stock(FULL)),basePrice(formattedValue,value),updateable),totalPrice(formattedValue),totalItems,totalPriceWithTax(formattedValue),totalDiscounts(value,formattedValue),subTotal(formattedValue),totalUnitCount,deliveryItemsQuantity,deliveryCost(formattedValue),totalTax(formattedValue,%20value),pickupItemsQuantity,net,appliedVouchers,productDiscounts(formattedValue),user&lang=en&curr=USD';
+
 class CartApi {
   final http = Dio();
 
   Future<Cart> fetchCart({String? cartCode}) async {
-    final response = await GetIt.instance
-        .get<Dio>(instanceName: Singletons.hybrisClient)
-        .get('${dotenv.get('HYBRIS_BASE_URL')}$PATH$cartCode$PARAMS');
+    try {
+      final response = await GetIt.instance
+          .get<Dio>(instanceName: Singletons.hybrisClient)
+          .get('${dotenv.get('HYBRIS_BASE_URL')}$PATH$cartCode$PARAMS');
 
-    return Cart.fromJson(response.data);
+      return Cart.fromJson(response.data);
+    } on DioException catch (e) {
+      // try to deserialize error response
+      if (e.response?.data != null) {
+        throw CartException.fromJson(e.response!.data['errors'].first);
+      }
+
+      rethrow;
+    }
+  }
+
+  Future<Cart> createCart() async {
+    try {
+      final response = await GetIt.instance
+          .get<Dio>(instanceName: Singletons.hybrisClient)
+          .post('${dotenv.get('HYBRIS_BASE_URL')}$PATH$PARAMS', data: {});
+
+      return Cart.fromJson(response.data);
+    } on DioException catch (_) {
+      rethrow;
+    }
   }
 
   Future<void> addProductToCart({

--- a/lib/cart/apis/cart_api.dart
+++ b/lib/cart/apis/cart_api.dart
@@ -24,7 +24,7 @@ class CartApi {
       return Cart.fromJson(response.data);
     } on DioException catch (e) {
       // try to deserialize error response
-      if (e.response?.data != null) {
+      if (e.response?.data?['errors']?.isNotEmpty) {
         throw CartException.fromJson(e.response!.data['errors'].first);
       }
 
@@ -33,15 +33,11 @@ class CartApi {
   }
 
   Future<Cart> createCart() async {
-    try {
-      final response = await GetIt.instance
-          .get<Dio>(instanceName: Singletons.hybrisClient)
-          .post('${dotenv.get('HYBRIS_BASE_URL')}$PATH$PARAMS', data: {});
+    final response = await GetIt.instance
+        .get<Dio>(instanceName: Singletons.hybrisClient)
+        .post('${dotenv.get('HYBRIS_BASE_URL')}$PATH$PARAMS', data: {});
 
-      return Cart.fromJson(response.data);
-    } on DioException catch (_) {
-      rethrow;
-    }
+    return Cart.fromJson(response.data);
   }
 
   Future<void> addProductToCart({

--- a/lib/cart/apis/cart_exceptions.dart
+++ b/lib/cart/apis/cart_exceptions.dart
@@ -1,0 +1,32 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'cart_exceptions.g.dart';
+
+enum CartExceptionReason {
+  notFound,
+}
+
+@JsonSerializable(createToJson: false)
+class CartException implements Exception {
+  final String message;
+  final CartExceptionReason reason;
+  final String subject;
+  final String subjectType;
+  final String type;
+
+  const CartException({
+    required this.message,
+    required this.reason,
+    required this.subject,
+    required this.subjectType,
+    required this.type,
+  });
+
+  factory CartException.fromJson(Map<String, dynamic> json) =>
+      _$CartExceptionFromJson(json);
+
+  @override
+  String toString() =>
+      'CartException{message: $message, reason: $reason, subject: $subject, '
+      'subjectType: $subjectType, type: $type}';
+}

--- a/lib/cart/apis/cart_exceptions.g.dart
+++ b/lib/cart/apis/cart_exceptions.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cart_exceptions.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CartException _$CartExceptionFromJson(Map<String, dynamic> json) =>
+    CartException(
+      message: json['message'] as String,
+      reason: $enumDecode(_$CartExceptionReasonEnumMap, json['reason']),
+      subject: json['subject'] as String,
+      subjectType: json['subjectType'] as String,
+      type: json['type'] as String,
+    );
+
+const _$CartExceptionReasonEnumMap = {
+  CartExceptionReason.notFound: 'notFound',
+};

--- a/lib/cart/cart_repository.dart
+++ b/lib/cart/cart_repository.dart
@@ -1,4 +1,5 @@
 import 'package:flex_storefront/cart/apis/cart_api.dart';
+import 'package:flex_storefront/cart/apis/cart_exceptions.dart';
 import 'package:flex_storefront/cart/models/cart.dart';
 import 'package:flex_storefront/cart/models/cart_message.dart';
 import 'package:flex_storefront/product_list/models/product.dart';
@@ -16,14 +17,29 @@ class CartRepository {
   final CartApi _cartApi;
 
   final _cartStreamController = BehaviorSubject<Cart>();
-  final _cartMessageStreamController = BehaviorSubject<CartMessage>.seeded(
-    CartReadyMessage(),
-  );
+  final _cartMessageStreamController =
+      BehaviorSubject<CartMessage>.seeded(CartInitialize());
 
   void init() async {
-    // TODO: proper initialization, find anonymous or user cart, or create one?
-    final cart = await _cartApi.fetchCart(cartCode: kTestCart);
-    _cartStreamController.add(cart);
+    // TODO: fetch previous carts from local storage
+    try {
+      final cart = await _cartApi.fetchCart(cartCode: kTestCart);
+      _cartStreamController.add(cart);
+    } on CartException catch (e) {
+      // if the cart is not found, create a new one
+      if (e.reason == CartExceptionReason.notFound) {
+        _cartMessageStreamController.add(CartNotFound());
+
+        final cart = await _cartApi.createCart();
+
+        _cartStreamController.add(cart);
+        _cartMessageStreamController.add(CartReady());
+      } else {
+        _cartStreamController.addError(e);
+      }
+    } catch (e) {
+      _cartStreamController.addError(e);
+    }
   }
 
   // Provide a [Stream] of the near real-time cart

--- a/lib/cart/models/cart_message.dart
+++ b/lib/cart/models/cart_message.dart
@@ -4,7 +4,11 @@ abstract class CartMessage {
   const CartMessage();
 }
 
-class CartReadyMessage extends CartMessage {}
+class CartInitialize extends CartMessage {}
+
+class CartNotFound extends CartMessage {}
+
+class CartReady extends CartMessage {}
 
 /// Add a product to the Cart.
 /// This event is fired when the product wasn't in the Cart before

--- a/lib/cart/models/cart_message.dart
+++ b/lib/cart/models/cart_message.dart
@@ -8,6 +8,8 @@ class CartInitialize extends CartMessage {}
 
 class CartNotFound extends CartMessage {}
 
+class CartCreate extends CartMessage {}
+
 class CartReady extends CartMessage {}
 
 /// Add a product to the Cart.


### PR DESCRIPTION
This PR improves Cart Initialization by handling the Cart `notFound` exception. It introduces a `CartException` class to deserialize DioErrors coming back from Cart API calls.

I expect this error handling implementation to change slightly and improve over time.