### PR TITLE
fix(33-search): Back button brings back to the original tab

### DIFF
--- a/lib/flex_ui/components/app_bar.dart
+++ b/lib/flex_ui/components/app_bar.dart
@@ -26,6 +26,7 @@ class FlexAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     final fromTab = RouteData.of(context).queryParams.optInt('fromTab');
+    final fullscreenDialog = RouteData.of(context).route.fullscreenDialog;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: FlexSizes.appPadding),
@@ -35,7 +36,7 @@ class FlexAppBar extends StatelessWidget implements PreferredSizeWidget {
             ? IconButton(
                 onPressed: onLeadingPressed ??
                     () {
-                      if (fromTab != null) {
+                      if (!fullscreenDialog && fromTab != null) {
                         AutoTabsRouter.of(context).setActiveIndex(fromTab);
                       }
 

--- a/lib/flex_ui/widgets/search/search_bar.dart
+++ b/lib/flex_ui/widgets/search/search_bar.dart
@@ -1,11 +1,21 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
+import 'package:flex_storefront/shared/navigation_helper.dart';
 import 'package:flutter/material.dart';
 
 class FlexSearchBar extends StatelessWidget {
-  const FlexSearchBar({super.key, this.autoFocus = false});
+  const FlexSearchBar({
+    super.key,
+    this.autoFocus = false,
+    this.fromTab,
+  });
 
   final bool autoFocus;
+
+  /// Customize the search result page back button behavior.
+  /// Example: if the search is initiated from the Home tab, the back button
+  /// on the search result page brings back to the Home tab.
+  final int? fromTab;
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +29,9 @@ class FlexSearchBar extends StatelessWidget {
       hintText: 'What are you looking for?',
       onSubmitted: (value) {
         context.maybePop();
-        context.router.navigateNamed('/shop/search?searchTerm=$value');
+        context.router.navigateNamed(
+          '/shop/search?searchTerm=$value'.withTabArg(fromTab),
+        );
       },
     );
   }

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -8,6 +8,7 @@ import 'package:flex_storefront/home/home_page_content.dart';
 import 'package:flex_storefront/flex_ui/widgets/search/search_bar.dart';
 import 'package:flex_storefront/home/widgets/search_bar_frame.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
+import 'package:flex_storefront/shared/navigation_helper.dart';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -57,6 +58,8 @@ class _HomeViewState extends State<HomeView> {
 
   @override
   Widget build(BuildContext context) {
+    final activeIndex = AutoTabsRouter.of(context).activeIndex;
+
     return CustomScrollView(
       controller: _scrollController,
       slivers: [
@@ -108,7 +111,9 @@ class _HomeViewState extends State<HomeView> {
                       const FlexSearchBar(),
                       GestureDetector(
                         onTap: () {
-                          context.router.pushNamed('/search');
+                          context.router.pushNamed(
+                            '/search'.withTabArg(activeIndex),
+                          );
                         },
                       ),
                     ],

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -19,6 +19,8 @@ class SearchView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final fromTab = RouteData.of(context).queryParams.optInt('fromTab');
+
     return Scaffold(
       appBar: FlexAppBar(
         showSearchButton: false,
@@ -27,8 +29,9 @@ class SearchView extends StatelessWidget {
         title: Container(
           height: kToolbarHeight,
           padding: const EdgeInsets.all(4.0),
-          child: const FlexSearchBar(
+          child: FlexSearchBar(
             autoFocus: true,
+            fromTab: fromTab,
           ),
         ),
       ),

--- a/lib/shared/navigation_helper.dart
+++ b/lib/shared/navigation_helper.dart
@@ -1,5 +1,9 @@
 extension LinkWithTabInfo on String {
-  String withTabArg(int tabIndex) {
+  String withTabArg(int? tabIndex) {
+    if (tabIndex == null) {
+      return this;
+    }
+
     final uri = Uri.parse(this);
 
     return '$this${uri.hasQuery ? '&' : '?'}fromTab=$tabIndex';


### PR DESCRIPTION
When the user clicks on search on the Home tab, the search result shows up in the Shop tab 👉 The back button navigates back to the Home tab (instead of showing the current Shop tab page)