### PR TITLE
feat(37): add account page scaffold

### DIFF
--- a/lib/account/account_page.dart
+++ b/lib/account/account_page.dart
@@ -1,6 +1,11 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:flex_storefront/account/widgets/account_header.dart';
+import 'package:flex_storefront/account/widgets/settings_list_tile.dart';
+import 'package:flex_storefront/account/widgets/settings_section_heading.dart';
 import 'package:flex_storefront/flex_ui/components/app_bar.dart';
+import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
 import 'package:flutter/material.dart';
+import 'package:icons_plus/icons_plus.dart';
 
 @RoutePage()
 class AccountPage extends StatelessWidget {
@@ -8,11 +13,92 @@ class AccountPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: FlexAppBar(
+    return Scaffold(
+      appBar: const FlexAppBar(
         title: Text('My Account'),
       ),
-      body: Center(child: Text('Account Page')),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const AccountHeader(),
+            const SizedBox(height: FlexSizes.spacerSection),
+            const SettingsSectionHeading(title: 'Account Settings'),
+            SettingsListTile(
+              title: 'Order History',
+              subtitle: 'View your previous orders',
+              trailing: const Icon(LineAwesome.arrow_right_solid),
+              onTap: () {},
+            ),
+            SettingsListTile(
+              title: 'Address Book',
+              subtitle: 'Manage your shipping addresses',
+              trailing: const Icon(LineAwesome.arrow_right_solid),
+              onTap: () {},
+            ),
+            SettingsListTile(
+              title: 'Payment Methods',
+              subtitle: 'Manage your payment methods',
+              trailing: const Icon(LineAwesome.arrow_right_solid),
+              onTap: () {},
+            ),
+            SettingsListTile(
+              title: 'Recently Viewed',
+              subtitle: 'View your recently viewed products',
+              trailing: const Icon(LineAwesome.arrow_right_solid),
+              onTap: () {},
+            ),
+            const SizedBox(height: FlexSizes.spacerSection),
+            const SettingsSectionHeading(title: 'App Settings'),
+            SettingsListTile(
+              title: 'Notifications',
+              subtitle: 'Manage your notification settings',
+              trailing: const Icon(LineAwesome.arrow_right_solid),
+              onTap: () {},
+            ),
+            SettingsListTile(
+              title: 'Change Language',
+              subtitle: 'View your previous orders',
+              trailing: const Icon(LineAwesome.arrow_right_solid),
+              onTap: () {},
+            ),
+            SettingsListTile(
+              title: 'Clear App Data',
+              subtitle: 'Clear all app data and cache',
+              trailing: const Icon(LineAwesome.arrow_right_solid),
+              onTap: () {},
+            ),
+            const SizedBox(height: FlexSizes.spacerSection),
+            const SettingsSectionHeading(title: 'Customer Service'),
+            SettingsListTile(
+              title: 'App Feedback',
+              subtitle: 'Send us your feedback',
+              trailing: const Icon(LineAwesome.arrow_right_solid),
+              onTap: () {},
+            ),
+            SettingsListTile(
+              title: 'Privacy & Terms',
+              subtitle: 'View our privacy policy and terms of service',
+              trailing: const Icon(LineAwesome.arrow_right_solid),
+              onTap: () {},
+            ),
+            SettingsListTile(
+              title: 'Contact Us',
+              subtitle: 'Get in touch with customer service',
+              trailing: const Icon(LineAwesome.arrow_right_solid),
+              onTap: () {},
+            ),
+            const Divider(),
+            Padding(
+              padding: const EdgeInsets.all(FlexSizes.appPadding),
+              child: ElevatedButton(
+                onPressed: () {},
+                child: const Text('Sign Out'),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/account/widgets/account_header.dart
+++ b/lib/account/widgets/account_header.dart
@@ -1,0 +1,28 @@
+import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
+import 'package:flutter/material.dart';
+
+class AccountHeader extends StatelessWidget {
+  const AccountHeader({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(FlexSizes.appPadding),
+      child: Column(
+        children: [
+          Text(
+            'Welcome!',
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: FlexSizes.xs),
+          Text(
+            'Sign in to access your account.',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/account/widgets/settings_list_tile.dart
+++ b/lib/account/widgets/settings_list_tile.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class SettingsListTile extends StatelessWidget {
+  const SettingsListTile({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.trailing,
+    this.onTap,
+  });
+
+  final String title;
+  final String? subtitle;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(
+        title,
+        style: Theme.of(context).textTheme.titleMedium,
+      ),
+      subtitle: subtitle != null
+          ? Text(
+              subtitle!,
+              style: Theme.of(context).textTheme.labelMedium,
+            )
+          : null,
+      trailing: trailing,
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/account/widgets/settings_section_heading.dart
+++ b/lib/account/widgets/settings_section_heading.dart
@@ -1,0 +1,24 @@
+import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
+import 'package:flutter/material.dart';
+
+class SettingsSectionHeading extends StatelessWidget {
+  const SettingsSectionHeading({
+    super.key,
+    required this.title,
+  });
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: FlexSizes.appPadding),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR adds the scaffold UI for a My Account page with sample list tiles.

![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-22 at 12 05 31](https://github.com/BASE1com/flex-storefront/assets/3759863/b28db7fb-975c-4a82-989f-abc70b258aae)
