### PR TITLE
feat(cart): add info cards

### DIFF
--- a/lib/cart/cart_page.dart
+++ b/lib/cart/cart_page.dart
@@ -31,6 +31,7 @@ class CartView extends StatelessWidget {
     return Scaffold(
       appBar: FlexAppBar(
         title: Text('Cart ${itemCount != null ? '($itemCount items)' : ''}'),
+        showSearchButton: false,
       ),
       body: BlocBuilder<CartPageCubit, CartPageState>(
         builder: (context, state) {

--- a/lib/cart/widgets/cart_info_card.dart
+++ b/lib/cart/widgets/cart_info_card.dart
@@ -3,10 +3,30 @@ import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
 import 'package:flutter/material.dart';
 
 enum CartInfoType {
-  info,
-  success,
-  warning,
-  error,
+  info(
+    cardColor: FlexColors.info,
+    textColor: FlexColors.onInfo,
+  ),
+  success(
+    cardColor: FlexColors.success,
+    textColor: FlexColors.onSuccess,
+  ),
+  warning(
+    cardColor: FlexColors.warning,
+    textColor: FlexColors.onWarning,
+  ),
+  error(
+    cardColor: FlexColors.error,
+    textColor: FlexColors.onError,
+  );
+
+  const CartInfoType({
+    required this.cardColor,
+    required this.textColor,
+  });
+
+  final Color cardColor;
+  final Color textColor;
 }
 
 class CartInfoCard extends StatelessWidget {
@@ -19,38 +39,10 @@ class CartInfoCard extends StatelessWidget {
   final CartInfoType type;
   final String message;
 
-  Color getCardColor() {
-    switch (type) {
-      case CartInfoType.success:
-        return FlexColors.success;
-      case CartInfoType.warning:
-        return FlexColors.warning;
-      case CartInfoType.error:
-        return FlexColors.error;
-      case CartInfoType.info:
-      default:
-        return FlexColors.info;
-    }
-  }
-
-  Color getTextColor() {
-    switch (type) {
-      case CartInfoType.success:
-        return FlexColors.onSuccess;
-      case CartInfoType.warning:
-        return FlexColors.onWarning;
-      case CartInfoType.error:
-        return FlexColors.onError;
-      case CartInfoType.info:
-      default:
-        return FlexColors.onInfo;
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return Card(
-      color: getCardColor(),
+      color: type.cardColor,
       elevation: 0,
       child: Padding(
         padding: const EdgeInsets.all(FlexSizes.md),
@@ -58,7 +50,7 @@ class CartInfoCard extends StatelessWidget {
           children: [
             Text(
               message,
-              style: TextStyle(color: getTextColor()),
+              style: TextStyle(color: type.textColor),
             ),
           ],
         ),

--- a/lib/cart/widgets/cart_info_card.dart
+++ b/lib/cart/widgets/cart_info_card.dart
@@ -1,0 +1,68 @@
+import 'package:flex_storefront/flex_ui/tokens/colors.dart';
+import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
+import 'package:flutter/material.dart';
+
+enum CartInfoType {
+  info,
+  success,
+  warning,
+  error,
+}
+
+class CartInfoCard extends StatelessWidget {
+  const CartInfoCard({
+    super.key,
+    this.type = CartInfoType.info,
+    required this.message,
+  });
+
+  final CartInfoType type;
+  final String message;
+
+  Color getCardColor() {
+    switch (type) {
+      case CartInfoType.success:
+        return FlexColors.success;
+      case CartInfoType.warning:
+        return FlexColors.warning;
+      case CartInfoType.error:
+        return FlexColors.error;
+      case CartInfoType.info:
+      default:
+        return FlexColors.info;
+    }
+  }
+
+  Color getTextColor() {
+    switch (type) {
+      case CartInfoType.success:
+        return FlexColors.onSuccess;
+      case CartInfoType.warning:
+        return FlexColors.onWarning;
+      case CartInfoType.error:
+        return FlexColors.onError;
+      case CartInfoType.info:
+      default:
+        return FlexColors.onInfo;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: getCardColor(),
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(FlexSizes.md),
+        child: Row(
+          children: [
+            Text(
+              message,
+              style: TextStyle(color: getTextColor()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/flex_ui/tokens/colors.dart
+++ b/lib/flex_ui/tokens/colors.dart
@@ -3,5 +3,17 @@ import 'package:flutter/material.dart';
 class FlexColors {
   static const primary = Color.fromRGBO(33, 39, 56, 1.0); // #212738
 
+  // information colors
+  static const info = Color.fromRGBO(0, 122, 255, 1.0); // #007AFF
+  static const success = Color.fromRGBO(34, 174, 69, 1); // #34C759
+  static const warning = Color.fromRGBO(255, 149, 0, 1.0); // #FF9500
+  static const error = Color.fromRGBO(255, 59, 48, 1.0); // #FF3B30
+  static const disabled = Color.fromRGBO(142, 142, 147, 1.0); // #8E8E93
+
   static const onPrimary = Color.fromRGBO(250, 250, 250, 1);
+  static const onInfo = Color.fromRGBO(250, 250, 250, 1);
+  static const onSuccess = Color.fromRGBO(250, 250, 250, 1);
+  static const onWarning = Color.fromRGBO(250, 250, 250, 1);
+  static const onError = Color.fromRGBO(250, 250, 250, 1);
+  static const onDisabled = Color.fromRGBO(250, 250, 250, 1);
 }


### PR DESCRIPTION
This PR adds info card widgets to the Cart feature. These can be used to display errors or potential promotions to let the user know the current status of their cart.

![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-22 at 12 40 16](https://github.com/BASE1com/flex-storefront/assets/3759863/3f9e5ba5-2311-4913-aa00-75a95854f1ad)
