### PR TITLE
fix(33-search): Parse HTML in search result items

### DIFF
--- a/lib/flex_ui/widgets/ecommerce/product_list_item.dart
+++ b/lib/flex_ui/widgets/ecommerce/product_list_item.dart
@@ -9,6 +9,7 @@ import 'package:flex_storefront/flex_ui/widgets/ecommerce/product_price.dart';
 import 'package:flex_storefront/flex_ui/widgets/ecommerce/quantity_selector.dart';
 import 'package:flex_storefront/flex_ui/widgets/ecommerce/star_rating.dart';
 import 'package:flex_storefront/product_list/models/product.dart';
+import 'package:flex_storefront/search/utils/emphasis_parsing.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter/material.dart';
@@ -49,9 +50,9 @@ class ProductListItem extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      product.name,
-                      style: Theme.of(context).textTheme.bodyLarge,
+                    EmphasisText(
+                      htmlString: product.name,
+                      style: EmphasisTextStyle.italic,
                     ),
                     if (product.averageRating != null)
                       StarRating(

--- a/lib/search/utils/emphasis_parsing.dart
+++ b/lib/search/utils/emphasis_parsing.dart
@@ -3,27 +3,75 @@ import 'package:flutter/material.dart';
 import 'package:html/dom.dart' as dom;
 import 'package:html/parser.dart';
 
-mixin EmphasisParsing {
-  Widget toRichText(String htmlString) {
+enum EmphasisTextStyle {
+  bold(
+    regularStyle: TextStyle(
+      color: Colors.black,
+      fontSize: FlexSizes.fontSizeLg,
+      fontWeight: FontWeight.normal,
+    ),
+    emphasisStyle: TextStyle(
+      fontWeight: FontWeight.bold,
+    ),
+  ),
+  invertedBold(
+    regularStyle: TextStyle(
+      color: Colors.black,
+      fontSize: FlexSizes.fontSizeLg,
+      fontWeight: FontWeight.bold,
+    ),
+    emphasisStyle: TextStyle(
+      fontWeight: FontWeight.normal,
+    ),
+  ),
+  italic(
+    regularStyle: TextStyle(
+      color: Colors.black,
+      fontSize: FlexSizes.fontSizeLg,
+      fontWeight: FontWeight.normal,
+    ),
+    emphasisStyle: TextStyle(
+      fontStyle: FontStyle.italic,
+    ),
+  );
+
+  const EmphasisTextStyle({
+    required this.regularStyle,
+    required this.emphasisStyle,
+  });
+
+  final TextStyle regularStyle;
+  final TextStyle emphasisStyle;
+}
+
+class EmphasisText extends StatelessWidget {
+  const EmphasisText({
+    super.key,
+    required this.htmlString,
+    required this.style,
+  });
+
+  /// Text content formatted in HTML. Only the <em> tags are parsed.
+  final String htmlString;
+
+  final EmphasisTextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
     final parsedHtml = parse(htmlString);
     final nodes = parsedHtml.getElementsByTagName('body')[0].nodes;
 
     return RichText(
       maxLines: null, // Authorize multi-lines without limit
       text: TextSpan(
-        style: const TextStyle(
-          color: Colors.black,
-          fontSize: FlexSizes.fontSizeLg,
-        ),
+        style: style.regularStyle,
         children: nodes.map(
           (node) {
             final emphasis = node is dom.Element && node.localName == 'em';
 
             return TextSpan(
               text: node.text,
-              style: TextStyle(
-                fontWeight: emphasis ? FontWeight.bold : FontWeight.normal,
-              ),
+              style: emphasis ? style.emphasisStyle : null,
             );
           },
         ).toList(),

--- a/lib/search/widgets/product_suggestion.dart
+++ b/lib/search/widgets/product_suggestion.dart
@@ -7,7 +7,7 @@ import 'package:flex_storefront/search/utils/emphasis_parsing.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-class ProductSuggestion extends StatelessWidget with EmphasisParsing {
+class ProductSuggestion extends StatelessWidget {
   const ProductSuggestion({
     super.key,
     required this.product,
@@ -40,7 +40,10 @@ class ProductSuggestion extends StatelessWidget with EmphasisParsing {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  toRichText(product.name),
+                  EmphasisText(
+                    htmlString: product.name,
+                    style: EmphasisTextStyle.invertedBold,
+                  ),
                   const SizedBox(height: FlexSizes.xs),
                   if (product.price != null)
                     ProductPrice(

--- a/lib/search/widgets/text_suggestion.dart
+++ b/lib/search/widgets/text_suggestion.dart
@@ -3,7 +3,7 @@ import 'package:flex_storefront/search/utils/emphasis_parsing.dart';
 import 'package:flex_storefront/shared/navigation_helper.dart';
 import 'package:flutter/material.dart';
 
-class TextSuggestion extends StatelessWidget with EmphasisParsing {
+class TextSuggestion extends StatelessWidget {
   const TextSuggestion({
     super.key,
     required this.suggestion,
@@ -25,9 +25,12 @@ class TextSuggestion extends StatelessWidget with EmphasisParsing {
     if (query != null) {
       final htmlSuggestion = suggestion.replaceFirst(query!, '<em>$query</em>');
 
-      text = toRichText(htmlSuggestion);
+      text = EmphasisText(
+        htmlString: htmlSuggestion,
+        style: EmphasisTextStyle.invertedBold,
+      );
     } else {
-      text = Text(query!);
+      text = Text(suggestion);
     }
 
     return InkWell(


### PR DESCRIPTION
Emphasis styles adjusted to match Spartacus web:

- Search suggestions 👉 Emphasize put on the non-matched parts (bold)
- PLP 👉 Emphasize on the matched parts (italic)

Before (Search)|After (Search)|Before (PLP)|After (PLP)
---------|-------------|------|------
![Simulator Screenshot - iPhone 15 - 2024-05-28 at 10 07 20](https://github.com/BASE1com/flex-storefront/assets/4425455/d136ca7d-aac9-49a3-83b6-1e323e4026eb)|![Simulator Screenshot - iPhone 15 - 2024-05-28 at 09 57 57](https://github.com/BASE1com/flex-storefront/assets/4425455/646f79ee-a88b-482b-8116-8420f064e16b)|![Simulator Screenshot - iPhone 15 - 2024-05-28 at 10 07 25](https://github.com/BASE1com/flex-storefront/assets/4425455/7d4e6693-7d70-48c5-b308-824442c4f75e)|![Simulator Screenshot - iPhone 15 - 2024-05-28 at 10 05 39](https://github.com/BASE1com/flex-storefront/assets/4425455/42ee3fd5-97cb-487e-8708-cda4e7fb3408)
