### PR TITLE
feat(ui): shimmer homepage on load

### DIFF
--- a/lib/flex_ui/components/carousel.dart
+++ b/lib/flex_ui/components/carousel.dart
@@ -53,15 +53,16 @@ class FlexCarouselShimmer extends StatelessWidget {
         vertical: FlexSizes.sm,
       ),
       child: Shimmer.fromColors(
-          baseColor: Colors.grey[300]!,
-          highlightColor: Colors.grey[100]!,
-          child: Container(
-            height: height,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(FlexSizes.borderRadiusLg),
-              color: Colors.white,
-            ),
-          )),
+        baseColor: Colors.grey[300]!,
+        highlightColor: Colors.grey[100]!,
+        child: Container(
+          height: height,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(FlexSizes.borderRadiusLg),
+            color: Colors.white,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/flex_ui/components/carousel.dart
+++ b/lib/flex_ui/components/carousel.dart
@@ -3,6 +3,7 @@ import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
 import 'package:flex_storefront/flex_ui/widgets/selectable_image.dart';
 import 'package:flutter_carousel_widget/flutter_carousel_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
@@ -32,6 +33,35 @@ class FlexCarousel extends StatelessWidget {
         ),
       ),
       items: items,
+    );
+  }
+}
+
+class FlexCarouselShimmer extends StatelessWidget {
+  const FlexCarouselShimmer({
+    super.key,
+    this.height = 132,
+  });
+
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: FlexSizes.appPadding,
+        vertical: FlexSizes.sm,
+      ),
+      child: Shimmer.fromColors(
+          baseColor: Colors.grey[300]!,
+          highlightColor: Colors.grey[100]!,
+          child: Container(
+            height: height,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(FlexSizes.borderRadiusLg),
+              color: Colors.white,
+            ),
+          )),
     );
   }
 }

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flex_storefront/cms/cubits/cms_cubit.dart';
 import 'package:flex_storefront/cms/cubits/cms_state.dart';
+import 'package:flex_storefront/flex_ui/components/carousel.dart';
 import 'package:flex_storefront/flex_ui/tokens/colors.dart';
 import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
 import 'package:flex_storefront/flex_ui/widgets/cached_image.dart';
@@ -139,8 +140,11 @@ class _HomeViewState extends State<HomeView> {
             builder: (_, state) {
               switch (state.status) {
                 case Status.initial || Status.pending:
-                  return const Center(
-                    child: CircularProgressIndicator(),
+                  return const Column(
+                    children: [
+                      FlexCarouselShimmer(),
+                      FlexCarouselShimmer(),
+                    ],
                   );
                 case Status.success:
                   return HomePageContent(sections: state.sections);


### PR DESCRIPTION
Add a `FlexCarouselShimmer` variation to shimmer the homepage loading.

![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-05 at 09 57 39](https://github.com/BASE1com/flex-storefront/assets/3759863/fcb34745-d250-41e1-97b0-1c421a6e2a22)
