### PR TITLE
ui: add flex roundedcard widget, clean up cart and checkout

### DIFF
--- a/lib/account/pages/addresses/new_address_page.dart
+++ b/lib/account/pages/addresses/new_address_page.dart
@@ -1,5 +1,4 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flex_storefront/account/cubits/address_cubit.dart';
 import 'package:flex_storefront/account/cubits/address_form_cubit.dart';
 import 'package:flex_storefront/account/cubits/address_form_state.dart';
 import 'package:flex_storefront/flex_ui/components/app_bar.dart';

--- a/lib/account/widgets/address_card.dart
+++ b/lib/account/widgets/address_card.dart
@@ -1,5 +1,6 @@
 import 'package:flex_storefront/checkout/models/address.dart';
 import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
+import 'package:flex_storefront/flex_ui/widgets/rounded_card.dart';
 import 'package:flutter/material.dart';
 
 class AddressCard extends StatelessWidget {
@@ -12,17 +13,7 @@ class AddressCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(FlexSizes.md),
-      margin: const EdgeInsets.only(bottom: FlexSizes.spacerItems),
-      decoration: BoxDecoration(
-        color: Colors.transparent,
-        borderRadius: BorderRadius.circular(FlexSizes.cardRadiusSm),
-        border: Border.all(
-          color: Colors.grey[300]!,
-        ),
-      ),
+    return RoundedCard(
       child: Stack(
         children: [
           Positioned(

--- a/lib/cart/cart_page.dart
+++ b/lib/cart/cart_page.dart
@@ -1,8 +1,10 @@
 import 'package:auto_route/annotations.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flex_storefront/cart/cubits/cart_page_cubit.dart';
 import 'package:flex_storefront/cart/cubits/cart_page_state.dart';
 import 'package:flex_storefront/cart/widgets/cart_content.dart';
 import 'package:flex_storefront/flex_ui/components/app_bar.dart';
+import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/material.dart';
@@ -48,6 +50,13 @@ class CartView extends StatelessWidget {
               );
           }
         },
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(FlexSizes.appPadding),
+        child: ElevatedButton(
+          onPressed: () => context.router.pushNamed('/checkout'),
+          child: const Text('Proceed to Checkout'),
+        ),
       ),
     );
   }

--- a/lib/cart/cubits/cart_page_cubit.dart
+++ b/lib/cart/cubits/cart_page_cubit.dart
@@ -52,6 +52,10 @@ class CartPageCubit extends Cubit<CartPageState> {
     required CartItem entry,
     required int quantity,
   }) async {
+    if (quantity == 0) {
+      return; // TODO: handle differently, either remove or show a dialog
+    }
+
     emit(state.copyWith(status: Status.pending));
 
     try {

--- a/lib/cart/widgets/cart_content.dart
+++ b/lib/cart/widgets/cart_content.dart
@@ -1,7 +1,8 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flex_storefront/cart/cubits/cart_page_cubit.dart';
 import 'package:flex_storefront/cart/widgets/cart_item_entry.dart';
 import 'package:flex_storefront/cart/widgets/order_summary.dart';
+import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
+import 'package:flex_storefront/flex_ui/widgets/rounded_card.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/material.dart';
 
@@ -20,24 +21,16 @@ class CartContent extends StatelessWidget {
           entry: entry,
         );
       }),
-      Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          OrderSummary(cart: cart),
-          const SizedBox(height: 8),
-          ElevatedButton(
-            onPressed: () => context.router.pushNamed('/checkout'),
-            child: const Text('Proceed to Checkout'),
-          ),
-        ],
-      ),
+      RoundedCard(child: OrderSummary(cart: cart)),
     ];
 
     return ListView.separated(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(FlexSizes.appPadding),
       itemCount: widgets.length,
       itemBuilder: (_, index) => widgets[index],
-      separatorBuilder: (_, __) => const Divider(height: 24),
+      separatorBuilder: (_, index) => index == widgets.length - 2
+          ? const SizedBox(height: FlexSizes.lg)
+          : const Divider(height: FlexSizes.lg),
     );
   }
 }

--- a/lib/checkout/checkout_page.dart
+++ b/lib/checkout/checkout_page.dart
@@ -6,7 +6,6 @@ import 'package:flex_storefront/checkout/cubits/checkout_page_cubit.dart';
 import 'package:flex_storefront/checkout/cubits/checkout_page_state.dart';
 import 'package:flex_storefront/checkout/cubits/delivery_mode_selection_cubit.dart';
 import 'package:flex_storefront/checkout/widgets/address_selection_card.dart';
-import 'package:flex_storefront/checkout/widgets/checkout_footer.dart';
 import 'package:flex_storefront/checkout/widgets/checkout_section.dart';
 import 'package:flex_storefront/checkout/widgets/delivery_mode_selection_card.dart';
 import 'package:flex_storefront/checkout/widgets/payment_selection_card.dart';

--- a/lib/checkout/checkout_page.dart
+++ b/lib/checkout/checkout_page.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/annotations.dart';
 import 'package:flex_storefront/cart/cubits/cart_page_cubit.dart';
+import 'package:flex_storefront/cart/widgets/order_summary.dart';
 import 'package:flex_storefront/checkout/cubits/address_selection_cubit.dart';
 import 'package:flex_storefront/checkout/cubits/checkout_page_cubit.dart';
 import 'package:flex_storefront/checkout/cubits/checkout_page_state.dart';
@@ -11,6 +12,7 @@ import 'package:flex_storefront/checkout/widgets/delivery_mode_selection_card.da
 import 'package:flex_storefront/checkout/widgets/payment_selection_card.dart';
 import 'package:flex_storefront/flex_ui/components/app_bar.dart';
 import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
+import 'package:flex_storefront/flex_ui/widgets/rounded_card.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -41,6 +43,8 @@ class CheckoutView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cart = context.select((CartPageCubit cubit) => cubit.state.cart);
+
     return Scaffold(
       appBar: const FlexAppBar(
         showSearchButton: false,
@@ -53,7 +57,7 @@ class CheckoutView extends StatelessWidget {
         children: [
           Expanded(
             child: ListView(
-              padding: const EdgeInsets.symmetric(horizontal: FlexSizes.md),
+              padding: const EdgeInsets.all(FlexSizes.appPadding),
               children: [
                 CheckoutSection(
                   title: 'Shipping Address',
@@ -113,10 +117,18 @@ class CheckoutView extends StatelessWidget {
                     }
                   }),
                 ),
+                const SizedBox(height: FlexSizes.spacerSection),
+                if (cart != null) ...[
+                  RoundedCard(child: OrderSummary(cart: cart)),
+                  ElevatedButton(
+                    onPressed: () {},
+                    child: const Text('Place Order'),
+                  ),
+                ],
+                const SizedBox(height: FlexSizes.spacerSection),
               ],
             ),
           ),
-          const CheckoutFooter(),
         ],
       ),
     );

--- a/lib/checkout/widgets/address_selection_card.dart
+++ b/lib/checkout/widgets/address_selection_card.dart
@@ -3,6 +3,7 @@ import 'package:collection/collection.dart';
 import 'package:flex_storefront/checkout/cubits/address_selection_cubit.dart';
 import 'package:flex_storefront/checkout/cubits/address_selection_state.dart';
 import 'package:flex_storefront/checkout/models/address.dart';
+import 'package:flex_storefront/flex_ui/widgets/rounded_card.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -60,27 +61,29 @@ class AddressSelectionCard extends StatelessWidget {
           (a) => a.id == state.selectedId,
         );
 
-        return Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            address != null
-                ? Text(address.multiLineFormat)
-                : const SizedBox.shrink(),
-            ElevatedButton(
-              onPressed: address != null
-                  ? () async {
-                      final address = await _showAddressSelection(
-                          context, state.addresses, state.selectedId);
+        return RoundedCard(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              address != null
+                  ? Text(address.multiLineFormat)
+                  : const SizedBox.shrink(),
+              ElevatedButton(
+                onPressed: address != null
+                    ? () async {
+                        final address = await _showAddressSelection(
+                            context, state.addresses, state.selectedId);
 
-                      if (address != null) {
-                        BlocProvider.of<AddressSelectionCubit>(context)
-                            .changeAddress(address.id!);
+                        if (address != null) {
+                          BlocProvider.of<AddressSelectionCubit>(context)
+                              .changeAddress(address.id!);
+                        }
                       }
-                    }
-                  : onAdd,
-              child: Text(address != null ? 'Change' : 'Add'),
-            ),
-          ],
+                    : onAdd,
+                child: Text(address != null ? 'Change' : 'Add'),
+              ),
+            ],
+          ),
         );
       },
     );

--- a/lib/checkout/widgets/address_selection_card.dart
+++ b/lib/checkout/widgets/address_selection_card.dart
@@ -1,4 +1,3 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:collection/collection.dart';
 import 'package:flex_storefront/checkout/cubits/address_selection_cubit.dart';
 import 'package:flex_storefront/checkout/cubits/address_selection_state.dart';

--- a/lib/checkout/widgets/checkout_section.dart
+++ b/lib/checkout/widgets/checkout_section.dart
@@ -1,3 +1,4 @@
+import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
 import 'package:flutter/material.dart';
 
 class CheckoutSection extends StatelessWidget {
@@ -15,7 +16,14 @@ class CheckoutSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(title, style: Theme.of(context).textTheme.titleMedium),
+        Text(
+          title,
+          style: Theme.of(context)
+              .textTheme
+              .titleMedium
+              ?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: FlexSizes.sm),
         content,
       ],
     );

--- a/lib/checkout/widgets/delivery_mode_selection_card.dart
+++ b/lib/checkout/widgets/delivery_mode_selection_card.dart
@@ -1,5 +1,7 @@
 import 'package:flex_storefront/checkout/cubits/delivery_mode_selection_cubit.dart';
 import 'package:flex_storefront/checkout/cubits/delivery_mode_selection_state.dart';
+import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
+import 'package:flex_storefront/flex_ui/widgets/rounded_card.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -18,30 +20,32 @@ class DeliveryModeSelectionCard extends StatelessWidget {
         builder: (context, state) {
       switch (state.status) {
         case Status.success:
-          return FormBuilder(
-            key: _formKey,
-            onChanged: () {
-              final code = _formKey.currentState!.instantValue['deliveryMode'];
-              print('Changed $code');
-              BlocProvider.of<DeliveryModeSelectionCubit>(context)
-                  .changeDeliveryMode(
-                code,
-              );
-            },
-            child: FormBuilderRadioGroup<String>(
-              name: 'deliveryMode',
-              initialValue: state.selectedCode,
-              orientation: OptionsOrientation.vertical,
-              options: state.deliveryModes
-                  .map(
-                    (d) => FormBuilderFieldOption(
-                      value: d.code,
-                      child: Text(
-                        '${d.name} ${d.description != null ? '(${d.description})' : ''}',
+          return RoundedCard(
+            padding: const EdgeInsets.all(0),
+            child: FormBuilder(
+              key: _formKey,
+              onChanged: () {
+                final code =
+                    _formKey.currentState!.instantValue['deliveryMode'];
+                BlocProvider.of<DeliveryModeSelectionCubit>(context)
+                    .changeDeliveryMode(code);
+              },
+              child: FormBuilderRadioGroup<String>(
+                name: 'deliveryMode',
+                initialValue: state.selectedCode,
+                orientation: OptionsOrientation.vertical,
+                decoration: const InputDecoration(border: InputBorder.none),
+                options: state.deliveryModes
+                    .map(
+                      (d) => FormBuilderFieldOption(
+                        value: d.code,
+                        child: Text(
+                          '${d.name} ${d.description != null ? '(${d.description})' : ''}',
+                        ),
                       ),
-                    ),
-                  )
-                  .toList(),
+                    )
+                    .toList(),
+              ),
             ),
           );
         default:

--- a/lib/checkout/widgets/delivery_mode_selection_card.dart
+++ b/lib/checkout/widgets/delivery_mode_selection_card.dart
@@ -1,6 +1,5 @@
 import 'package:flex_storefront/checkout/cubits/delivery_mode_selection_cubit.dart';
 import 'package:flex_storefront/checkout/cubits/delivery_mode_selection_state.dart';
-import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
 import 'package:flex_storefront/flex_ui/widgets/rounded_card.dart';
 import 'package:flex_storefront/shared/bloc_helper.dart';
 import 'package:flutter/material.dart';

--- a/lib/checkout/widgets/payment_selection_card.dart
+++ b/lib/checkout/widgets/payment_selection_card.dart
@@ -1,5 +1,5 @@
-import 'package:flex_storefront/checkout/models/address.dart';
 import 'package:flex_storefront/checkout/models/payment_info.dart';
+import 'package:flex_storefront/flex_ui/widgets/rounded_card.dart';
 import 'package:flutter/material.dart';
 import 'package:icons_plus/icons_plus.dart';
 
@@ -17,29 +17,32 @@ class PaymentSelectionCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        if (paymentInfo != null) ...[
-          Column(
-            children: [
-              Text(paymentInfo!.accountHolderName),
-              Text(paymentInfo!.cardNumber),
-              Text(
-                'Expires: ${paymentInfo!.expiryMonth.padLeft(2, '0')}/${paymentInfo!.expiryYear}',
-              ),
-            ],
+    return RoundedCard(
+      child: Row(
+        children: [
+          if (paymentInfo == null) const Text('Select a payment method'),
+          if (paymentInfo != null) ...[
+            Column(
+              children: [
+                Text(paymentInfo!.accountHolderName),
+                Text(paymentInfo!.cardNumber),
+                Text(
+                  'Expires: ${paymentInfo!.expiryMonth.padLeft(2, '0')}/${paymentInfo!.expiryYear}',
+                ),
+              ],
+            ),
+            if (paymentInfo!.cardType.code == 'visa')
+              const Icon(LineAwesome.cc_visa),
+            if (paymentInfo!.cardType.code == 'mastercard')
+              const Icon(LineAwesome.cc_mastercard),
+          ],
+          const Expanded(child: SizedBox.shrink()),
+          ElevatedButton(
+            onPressed: paymentInfo != null ? onChange : onAdd,
+            child: Text(paymentInfo != null ? 'Change' : 'Add'),
           ),
-          if (paymentInfo!.cardType.code == 'visa')
-            const Icon(LineAwesome.cc_visa),
-          if (paymentInfo!.cardType.code == 'mastercard')
-            const Icon(LineAwesome.cc_mastercard),
         ],
-        const Expanded(child: SizedBox.shrink()),
-        ElevatedButton(
-          onPressed: paymentInfo != null ? onChange : onAdd,
-          child: Text(paymentInfo != null ? 'Change' : 'Add'),
-        ),
-      ],
+      ),
     );
   }
 }

--- a/lib/flex_ui/widgets/rounded_card.dart
+++ b/lib/flex_ui/widgets/rounded_card.dart
@@ -1,0 +1,36 @@
+import 'package:flex_storefront/flex_ui/tokens/sizes.dart';
+import 'package:flutter/material.dart';
+
+class RoundedCard extends StatelessWidget {
+  const RoundedCard({
+    super.key,
+    required this.child,
+    this.padding,
+    this.margin,
+    this.borderRadius = FlexSizes.cardRadiusSm,
+    this.borderColor,
+  });
+
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final EdgeInsetsGeometry? margin;
+  final double borderRadius;
+  final Color? borderColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: padding ?? const EdgeInsets.all(FlexSizes.md),
+      margin: margin ?? const EdgeInsets.only(bottom: FlexSizes.spacerItems),
+      decoration: BoxDecoration(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(borderRadius),
+        border: Border.all(
+          color: borderColor ?? Colors.grey[300]!,
+        ),
+      ),
+      child: child,
+    );
+  }
+}

--- a/lib/home/home_page_content.dart
+++ b/lib/home/home_page_content.dart
@@ -37,6 +37,9 @@ class HomePageContent extends StatelessWidget {
           aspectRatio: section.aspectRatio,
           imageUrl: section.banner.url,
           borderRadius: FlexSizes.borderRadiusMd,
+          padding: const EdgeInsets.symmetric(
+            horizontal: FlexSizes.appPadding,
+          ),
           onTap: () {
             context.router.navigateNamed(section.link.withTabArg(activeIndex));
           },


### PR DESCRIPTION
This PR uses the new `RoundedCard` widget to clean up Cart and Checkout pages..

![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-05 at 10 16 29](https://github.com/BASE1com/flex-storefront/assets/3759863/9c449155-974c-472d-b209-e32421b13bb1)
