### PR TITLE
PLP: Fix page pending reposition issue

### DIFF
--- a/lib/checkout/cubits/checkout_page_state.dart
+++ b/lib/checkout/cubits/checkout_page_state.dart
@@ -1,5 +1,4 @@
 import 'package:flex_storefront/checkout/models/checkout_info.dart';
-import 'package:flex_storefront/shared/bloc_helper.dart';
 
 enum CheckoutPageStatus {
   initial,

--- a/lib/product_list/cubits/product_search_cubit.dart
+++ b/lib/product_list/cubits/product_search_cubit.dart
@@ -3,27 +3,26 @@ import 'package:dio/dio.dart';
 import 'package:flex_storefront/product_list/apis/product_list_api.dart';
 import 'package:flex_storefront/product_list/cubits/product_search_state.dart';
 import 'package:flex_storefront/search/models/search_results.dart';
-import 'package:flex_storefront/shared/bloc_helper.dart';
 import 'package:get_it/get_it.dart';
 
 class ProductSearchCubit extends Cubit<ProductSearchState> {
   ProductSearchCubit()
       : super(ProductSearchState(
-          status: Status.initial,
+          status: ProductSearchStatus.initial,
           pagination: Pagination.empty(),
         ));
 
   Future<void> searchProductsAutocomplete({
     required String query,
   }) async {
-    emit(state.copyWith(status: Status.pending));
+    emit(state.copyWith(status: ProductSearchStatus.pending));
 
     final searchResults = await GetIt.instance
         .get<ProductListApi>()
         .searchProducts(query: query, limit: 5);
 
     emit(state.copyWith(
-      status: Status.success,
+      status: ProductSearchStatus.success,
       searchResults: searchResults,
       products: searchResults.products,
     ));
@@ -36,7 +35,7 @@ class ProductSearchCubit extends Cubit<ProductSearchState> {
     FacetValue? filterBy,
   }) async {
     try {
-      emit(state.copyWith(status: Status.pending));
+      emit(state.copyWith(status: ProductSearchStatus.pending));
 
       final currentQuery = state.searchResults?.currentQuery;
       String query;
@@ -62,7 +61,7 @@ class ProductSearchCubit extends Cubit<ProductSearchState> {
         ..sort((a, b) => a.priority.compareTo(b.priority));
 
       emit(state.copyWith(
-        status: Status.success,
+        status: ProductSearchStatus.success,
         searchResults: searchResults,
         breadcrumbs: searchResults.breadcrumbs,
         facets: facets,
@@ -71,7 +70,7 @@ class ProductSearchCubit extends Cubit<ProductSearchState> {
       ));
     } on DioException catch (error) {
       emit(state.copyWith(
-        status: Status.failure,
+        status: ProductSearchStatus.failure,
         error: error,
         stackTrace: error.stackTrace,
       ));
@@ -81,12 +80,12 @@ class ProductSearchCubit extends Cubit<ProductSearchState> {
   Future<void> nextPage() async {
     if (state.pagination.currentPage + 1 >= state.pagination.totalPages ||
         state.searchResults == null ||
-        state.status == Status.pending) {
+        state.status == ProductSearchStatus.pagePending) {
       return;
     }
 
     try {
-      emit(state.copyWith(status: Status.pending));
+      emit(state.copyWith(status: ProductSearchStatus.pagePending));
 
       final searchResults =
           await GetIt.instance.get<ProductListApi>().searchProducts(
@@ -95,7 +94,7 @@ class ProductSearchCubit extends Cubit<ProductSearchState> {
               );
 
       emit(state.copyWith(
-        status: Status.success,
+        status: ProductSearchStatus.success,
         searchResults: searchResults,
         breadcrumbs: searchResults.breadcrumbs,
         facets: searchResults.facets,
@@ -104,7 +103,7 @@ class ProductSearchCubit extends Cubit<ProductSearchState> {
       ));
     } on DioException catch (error) {
       emit(state.copyWith(
-        status: Status.failure,
+        status: ProductSearchStatus.failure,
         error: error,
         stackTrace: error.stackTrace,
       ));

--- a/lib/product_list/cubits/product_search_state.dart
+++ b/lib/product_list/cubits/product_search_state.dart
@@ -1,8 +1,16 @@
 import 'package:flex_storefront/product_list/models/product.dart';
 import 'package:flex_storefront/search/models/search_results.dart';
-import 'package:flex_storefront/shared/bloc_helper.dart';
 
-class ProductSearchState extends BlocState {
+enum ProductSearchStatus {
+  initial,
+  pending,
+  failure,
+  success,
+  pagePending,
+}
+
+class ProductSearchState {
+  final ProductSearchStatus status;
   final List<Breadcrumb> breadcrumbs;
   final List<Facet> facets;
   final List<Product> products;
@@ -10,9 +18,7 @@ class ProductSearchState extends BlocState {
   final SearchResults? searchResults;
 
   ProductSearchState({
-    required super.status,
-    super.error,
-    super.stackTrace,
+    required this.status,
     this.breadcrumbs = const [],
     this.facets = const [],
     this.products = const [],
@@ -21,7 +27,7 @@ class ProductSearchState extends BlocState {
   });
 
   ProductSearchState copyWith({
-    Status? status,
+    ProductSearchStatus? status,
     Object? error,
     StackTrace? stackTrace,
     List<Breadcrumb>? breadcrumbs,
@@ -32,8 +38,6 @@ class ProductSearchState extends BlocState {
   }) {
     return ProductSearchState(
       status: status ?? this.status,
-      error: error ?? this.error,
-      stackTrace: stackTrace ?? this.stackTrace,
       breadcrumbs: breadcrumbs ?? this.breadcrumbs,
       facets: facets ?? this.facets,
       products: products ?? this.products,

--- a/lib/product_list/product_list_page.dart
+++ b/lib/product_list/product_list_page.dart
@@ -5,7 +5,6 @@ import 'package:flex_storefront/flex_ui/widgets/ecommerce/product_list_item.dart
 import 'package:flex_storefront/flex_ui/widgets/search/search_results_header.dart';
 import 'package:flex_storefront/product_list/cubits/product_search_cubit.dart';
 import 'package:flex_storefront/product_list/cubits/product_search_state.dart';
-import 'package:flex_storefront/shared/bloc_helper.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/material.dart';
 
@@ -61,9 +60,8 @@ class _ProductListViewState extends State<ProductListView> {
   Widget build(BuildContext context) {
     return BlocBuilder<ProductSearchCubit, ProductSearchState>(
       builder: (context, state) {
-        // switch on ProductSearchState status
         switch (state.status) {
-          case Status.initial || Status.pending:
+          case ProductSearchStatus.initial || ProductSearchStatus.pending:
             return const Column(
               children: [
                 SearchResultsHeaderShimmer(),
@@ -72,7 +70,7 @@ class _ProductListViewState extends State<ProductListView> {
                 ProductListItemShimmer(),
               ],
             );
-          case Status.success:
+          case ProductSearchStatus.success || ProductSearchStatus.pagePending:
             return Column(
               children: [
                 if (state.searchResults != null)
@@ -85,10 +83,6 @@ class _ProductListViewState extends State<ProductListView> {
                       searchResults: state.searchResults!,
                     ),
                   ),
-                if (state.status == Status.failure)
-                  const Center(child: Text('Failed to load products')),
-                if (state.status == Status.pending)
-                  const Center(child: CircularProgressIndicator()),
                 Expanded(
                   child: ListView.separated(
                     controller: controller,
@@ -100,7 +94,7 @@ class _ProductListViewState extends State<ProductListView> {
                     itemBuilder: (context, i) {
                       // handle the last item
                       if (i == state.products.length) {
-                        if (state.status == Status.pending) {
+                        if (state.status == ProductSearchStatus.pagePending) {
                           return const ProductListItemShimmer();
                         }
 
@@ -115,7 +109,6 @@ class _ProductListViewState extends State<ProductListView> {
                                 ))
                             : const ProductListItemShimmer();
                       }
-
                       return ProductListItem(
                         key: Key(state.products[i].code),
                         product: state.products[i],
@@ -125,7 +118,7 @@ class _ProductListViewState extends State<ProductListView> {
                 ),
               ],
             );
-          case Status.failure:
+          case ProductSearchStatus.failure:
             return const Center(child: Text('Failed to load products'));
         }
       },


### PR DESCRIPTION
This fixes an issue where flipping to a `pending` status would rebuild the entire page widget.