### PR TITLE
chore(ci): only build off main branch

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,5 +1,8 @@
 name: CI Build
-on: [push]
+on: 
+  push:
+    branches:
+      - main
 jobs:
   Android:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR changes the CI/CD workflow to only build new releases for App Distribution from `main` branch